### PR TITLE
Rust go :rocket: :rocket: :rocket: 

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -4,7 +4,7 @@
 
 use clap::Command;
 
-pub fn install_command() -> Command {
+pub fn command() -> Command {
     Command::new("install")
         .about("Install packages")
         .long_about("Install the requested software to the local system")

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -4,7 +4,7 @@
 
 use clap::{ArgMatches, Command};
 
-pub fn list_command() -> Command {
+pub fn command() -> Command {
     Command::new("list")
         .about("List packages")
         .long_about("List packages according to a filter")
@@ -22,6 +22,6 @@ pub fn list_command() -> Command {
 }
 
 /// Handle listing by filter
-pub fn list_command_handler(_: &ArgMatches) {
+pub fn handle(_: &ArgMatches) {
     println!("Listage");
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -9,15 +9,8 @@ mod list;
 mod remove;
 mod version;
 
-use self::{
-    install::install_command,
-    list::{list_command, list_command_handler},
-    remove::remove_command,
-    version::*,
-};
-
 /// Generate the CLI command structure
-fn cli_main() -> Command {
+fn command() -> Command {
     Command::new("moss")
         .about("Next generation package manager")
         .arg(
@@ -27,22 +20,22 @@ fn cli_main() -> Command {
                 .action(ArgAction::SetTrue),
         )
         .arg_required_else_help(true)
-        .subcommand(list_command())
-        .subcommand(install_command())
-        .subcommand(remove_command())
-        .subcommand(version_command())
+        .subcommand(list::command())
+        .subcommand(install::command())
+        .subcommand(remove::command())
+        .subcommand(version::command())
 }
 
 /// Process all CLI arguments
 pub fn process() {
-    let matches = cli_main().get_matches();
+    let matches = command().get_matches();
     if matches.get_flag("version") {
-        print_version();
+        version::print();
         return;
     }
-    match cli_main().get_matches().subcommand() {
-        Some(("version", _)) => print_version(),
-        Some(("list", a)) => list_command_handler(a),
+    match command().get_matches().subcommand() {
+        Some(("version", _)) => version::print(),
+        Some(("list", a)) => list::handle(a),
         _ => unreachable!(),
     }
 }

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -4,7 +4,7 @@
 
 use clap::Command;
 
-pub fn remove_command() -> Command {
+pub fn command() -> Command {
     Command::new("remove")
         .about("Remove packages")
         .long_about("Remove packages by name")

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -4,6 +4,8 @@
 
 use clap::Command;
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 /// Construct the Version command
 pub fn command() -> Command {
     Command::new("version").about("Display version and exit")
@@ -11,5 +13,5 @@ pub fn command() -> Command {
 
 /// Print program version
 pub fn print() {
-    println!("TODO: Set a version");
+    println!("moss {VERSION}");
 }

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -5,11 +5,11 @@
 use clap::Command;
 
 /// Construct the Version command
-pub fn version_command() -> Command {
+pub fn command() -> Command {
     Command::new("version").about("Display version and exit")
 }
 
 /// Print program version
-pub fn print_version() {
+pub fn print() {
     println!("TODO: Set a version");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,9 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use moss::cli::process;
+use moss::cli;
 
 /// Main entry point
 fn main() {
-    process()
+    cli::process();
 }


### PR DESCRIPTION
A couple minor things while this repo gets setup


### Version 

We can use this built-in env var to get the package version: https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates. If we want to include git hash, we can easily leverage `build.rs` to set an env var w/ that hash value. I can add this in a follow-up unit of work.

### Naming Convention

This one is a bit subjective, but I want to throw it out there. Rust modules offer a nice namespace so we shouldn't need to have redundant module names in the types or functions themselves:

```rs
mod list;

list::command()

// vs

use list::list_command; // redundant

mod list;

list_command()
```