### PR TITLE
moss/cli: add -D and -y global arguments

### DIFF
--- a/moss/src/cli/mod.rs
+++ b/moss/src/cli/mod.rs
@@ -23,6 +23,23 @@ fn command() -> Command {
                 .long("version")
                 .action(ArgAction::SetTrue),
         )
+        .arg(
+            Arg::new("root")
+                .short('D')
+                .long("directory")
+                .global(true)
+                .help("Root directory")
+                .action(ArgAction::Set)
+                .default_value("/"),
+        )
+        .arg(
+            Arg::new("yes")
+                .short('y')
+                .long("yes-all")
+                .global(true)
+                .help("Assume yes for all questions")
+                .action(ArgAction::SetTrue),
+        )
         .arg_required_else_help(true)
         .subcommand(extract::command())
         .subcommand(info::command())


### PR DESCRIPTION
`cargo run -p moss -- -h`:
```
Next generation package manager

Usage: moss [OPTIONS] [COMMAND]

Commands:
  extract  Extract a `.stone` content to disk
  info     Query packages
  inspect  Examine raw stone files
  install  Install packages
  list     List packages
  remove   Remove packages
  version  Display version and exit
  help     Print this message or the help of the given subcommand(s)

Options:
  -v, --version           
  -D, --directory <root>  Root directory [default: /]
  -y, --yes-all           Assume yes for all questions
  -h, --help              Print help
```

`cargo run -p moss -- install -h`:
```
Install packages

Usage: moss install [OPTIONS]

Options:
  -D, --directory <root>  Root directory [default: /]
  -y, --yes-all           Assume yes for all questions
  -h, --help              Print help (see more with '--help')
```

To obtain the value, use something like:
```rust
let root = args.get_one::<String>("root").unwrap().clone();
let yes = args.get_flag("yes");
```