### PR TITLE
Extract content in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,6 +1135,7 @@ dependencies = [
  "itertools 0.11.0",
  "log",
  "nix",
+ "rayon",
  "reqwest",
  "serde",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ futures = "0.3.28"
 log = "0.4"
 nix = { version = "0.27.1", features = ["user", "fs"] }
 ratatui = "0.23.1-alpha.1"
+rayon = "1.7"
 reqwest = { version = "0.11.20", default-features = false, features = ["rustls-tls", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"

--- a/moss/Cargo.toml
+++ b/moss/Cargo.toml
@@ -14,6 +14,7 @@ itertools.workspace = true
 futures.workspace = true
 log.workspace = true
 nix.workspace = true
+rayon.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_yaml.workspace = true


### PR DESCRIPTION
An example of doing `copy` in parallel from the stone content file to the store.

It appears to be around 20% faster based on some benchmarking