### PR TITLE
Use vec instead of btreeset

### DIFF
--- a/moss/src/package/render.rs
+++ b/moss/src/package/render.rs
@@ -15,7 +15,7 @@ use crate::Package;
 const COLUMN_PADDING: usize = 4;
 
 /// Allow display packages in column form
-impl ColumnDisplay for Package {
+impl<'a> ColumnDisplay for &'a Package {
     fn get_display_width(&self) -> usize {
         self.meta.name.to_string().len()
             + self.meta.version_identifier.len()

--- a/moss/src/registry/plugin/mod.rs
+++ b/moss/src/registry/plugin/mod.rs
@@ -124,23 +124,6 @@ impl Plugin {
     }
 }
 
-/// Defines a [`Plugin`] ordering based on "priority", sorted
-/// highest to lowest
-#[derive(Debug, PartialEq, Eq)]
-pub(super) struct PriorityOrdered(pub Plugin);
-
-impl PartialOrd for PriorityOrdered {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for PriorityOrdered {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.0.priority().cmp(&other.0.priority()).reverse()
-    }
-}
-
 #[cfg(test)]
 pub mod test {
     use std::path::PathBuf;


### PR DESCRIPTION
Plugins can have priority collision so we can't use btreeset. Ordering is now guaranteed by sorting during query iteration.