### PR TITLE
Store dag in transaction and use w/ remove

### DIFF
--- a/dag/src/lib.rs
+++ b/dag/src/lib.rs
@@ -2,12 +2,14 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-pub mod subgraph;
-
 pub use self::reexport::*;
+pub use self::subgraph::subgraph;
+
+mod subgraph;
 
 pub mod reexport {
     pub use petgraph::algo::{toposort, Cycle};
     pub use petgraph::graph::DiGraph;
+    pub use petgraph::graphmap::DiGraphMap;
     pub use petgraph::visit::Dfs;
 }

--- a/dag/src/subgraph.rs
+++ b/dag/src/subgraph.rs
@@ -2,27 +2,36 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use petgraph::{prelude::GraphMap, visit::Dfs, EdgeType};
+use petgraph::{prelude::Graph, stable_graph::IndexType, visit::Dfs, EdgeType};
 
-/// Given an input [GraphMap] and the start nodes, construct a subgraph
+/// Given an input [`Graph`] and the start nodes, construct a subgraph
 /// Used largely in transposed form for reverse dependency calculation
-pub fn subgraph<V, E, Ty>(graph: &GraphMap<V, E, Ty>, starting_nodes: Vec<V>) -> GraphMap<V, E, Ty>
+pub fn subgraph<N, E, Ty, Ix>(graph: &Graph<N, E, Ty, Ix>, starting_nodes: &[N]) -> Graph<N, E, Ty>
 where
-    V: Eq + std::hash::Hash + Ord + Copy,
+    N: PartialEq + Clone,
     E: Default,
+    Ix: IndexType,
     Ty: EdgeType,
 {
-    let mut res = GraphMap::default();
+    let mut res = Graph::default();
 
     let mut dfs = Dfs::empty(&graph);
     for starting_node in starting_nodes {
-        dfs.move_to(starting_node);
+        let node_index = res.add_node(starting_node.clone());
+
+        let Some(starting_node_index) = graph.node_indices().find(|n| graph[*n] == *starting_node)
+        else {
+            continue;
+        };
+
+        dfs.move_to(starting_node_index);
+
         while let Some(node) = dfs.next(&graph) {
-            res.extend(
-                graph
-                    .neighbors_directed(node, petgraph::Direction::Outgoing)
-                    .map(|adj| (node, adj)),
-            );
+            for neighbor in graph.neighbors_directed(node, petgraph::Direction::Outgoing) {
+                let neighbor_node = graph[neighbor].clone();
+                let neighbor_index = res.add_node(neighbor_node);
+                res.add_edge(node_index, neighbor_index, E::default());
+            }
         }
     }
 
@@ -32,7 +41,8 @@ where
 #[cfg(test)]
 mod test {
     use petgraph::{
-        prelude::DiGraphMap,
+        data::{Element, FromElements},
+        prelude::DiGraph,
         visit::{Reversed, Topo, Walker},
     };
 
@@ -40,34 +50,117 @@ mod test {
 
     #[test]
     fn basic_topo() {
-        let graph: DiGraphMap<i32, ()> = DiGraphMap::from_edges(&[(1, 2), (1, 3), (2, 3)]);
-        let subg = subgraph(&graph, vec![1]);
+        let graph: DiGraph<i32, ()> = DiGraph::from_elements([
+            Element::Node { weight: 1 },
+            Element::Node { weight: 2 },
+            Element::Node { weight: 3 },
+            Element::Node { weight: 4 },
+            Element::Edge {
+                source: 0,
+                target: 1,
+                weight: (),
+            },
+            Element::Edge {
+                source: 0,
+                target: 2,
+                weight: (),
+            },
+            Element::Edge {
+                source: 1,
+                target: 2,
+                weight: (),
+            },
+            Element::Edge {
+                source: 2,
+                target: 3,
+                weight: (),
+            },
+        ]);
+        let subg = subgraph(&graph, &[2]);
         let topo = Topo::new(&subg);
-        let order: Vec<i32> = topo.iter(&subg).collect();
+        let order: Vec<i32> = topo.iter(&subg).map(|n| subg[n]).collect();
 
-        assert_eq!(order, vec![1, 2, 3]);
+        assert_eq!(order, vec![2, 3, 4]);
     }
 
     #[test]
     fn reverse_topo() {
-        let graph: DiGraphMap<i32, ()> = DiGraphMap::from_edges(&[(1, 2), (1, 3), (2, 3)]);
-        let items = vec![1];
-        let subg = subgraph(&graph, items);
+        let graph: DiGraph<i32, ()> = DiGraph::from_elements([
+            Element::Node { weight: 1 },
+            Element::Node { weight: 2 },
+            Element::Node { weight: 3 },
+            Element::Node { weight: 4 },
+            Element::Edge {
+                source: 0,
+                target: 1,
+                weight: (),
+            },
+            Element::Edge {
+                source: 0,
+                target: 2,
+                weight: (),
+            },
+            Element::Edge {
+                source: 1,
+                target: 2,
+                weight: (),
+            },
+            Element::Edge {
+                source: 2,
+                target: 3,
+                weight: (),
+            },
+        ]);
+        let subg = subgraph(&graph, &[2]);
         let revg = Reversed(&subg);
-        let removal: Vec<i32> = Topo::new(revg).iter(revg).collect();
-        assert_eq!(removal, vec![3, 2, 1]);
+        let removal: Vec<i32> = Topo::new(revg).iter(revg).map(|n| subg[n]).collect();
+        assert_eq!(removal, vec![4, 3, 2]);
     }
 
     // TODO: break cycles!
     #[ignore = "cycles breaking needs to be implemented"]
     #[test]
     fn cyclic_topo() {
-        let graph: DiGraphMap<i32, ()> =
-            DiGraphMap::from_edges(&[(1, 2), (1, 3), (2, 4), (2, 5), (3, 5), (4, 1)]);
-        let items = vec![1, 4];
-        let subg = subgraph(&graph, items);
+        let graph: DiGraph<i32, ()> = DiGraph::from_elements([
+            Element::Node { weight: 1 },
+            Element::Node { weight: 2 },
+            Element::Node { weight: 3 },
+            Element::Node { weight: 4 },
+            Element::Node { weight: 5 },
+            Element::Edge {
+                source: 0,
+                target: 1,
+                weight: (),
+            },
+            Element::Edge {
+                source: 0,
+                target: 2,
+                weight: (),
+            },
+            Element::Edge {
+                source: 1,
+                target: 3,
+                weight: (),
+            },
+            Element::Edge {
+                source: 1,
+                target: 4,
+                weight: (),
+            },
+            Element::Edge {
+                source: 2,
+                target: 4,
+                weight: (),
+            },
+            Element::Edge {
+                source: 3,
+                target: 0,
+                weight: (),
+            },
+        ]);
+        let subg = subgraph(&graph, &[1, 4]);
         let revg = Reversed(&subg);
-        let removal: Vec<i32> = Topo::new(revg).iter(revg).collect();
+        let removal: Vec<i32> = Topo::new(revg).iter(revg).map(|n| subg[n]).collect();
         assert_eq!(removal, vec![5, 3, 4, 2, 1]);
     }
 }

--- a/moss/src/cli/install.rs
+++ b/moss/src/cli/install.rs
@@ -79,7 +79,7 @@ pub async fn handle(args: &ArgMatches, root: &Path) -> Result<(), Error> {
 
     // Resolve and map it. Remove any installed items. OK to unwrap here because they're resolved already
     let results = join_all(
-        tx.finalize()
+        tx.finalize()?
             .iter()
             .map(|p| async { client.registry.by_id(p).boxed().next().await.unwrap() }),
     )

--- a/moss/src/cli/remove.rs
+++ b/moss/src/cli/remove.rs
@@ -71,7 +71,7 @@ pub async fn handle(args: &ArgMatches, root: &Path) -> Result<(), Error> {
     transaction.remove(for_removal).await?;
 
     // Finalized tx has all reverse deps removed
-    let finalized = transaction.finalize();
+    let finalized = transaction.finalize()?.into_iter().collect::<HashSet<_>>();
 
     // Difference resolves to all removed pkgs
     let removed = installed_ids.difference(&finalized);


### PR DESCRIPTION
Alternative implementation of `remove` using transposed subgraph. We need to store dag in transaction so it's available for use in `remove` after `add`.