### PR TITLE
Feat/remote blit

### DIFF
--- a/moss/src/cli/info.rs
+++ b/moss/src/cli/info.rs
@@ -36,7 +36,7 @@ pub async fn handle(args: &ArgMatches) -> Result<(), Error> {
         .collect::<Vec<_>>();
 
     let root = args.get_one::<PathBuf>("root").unwrap().clone();
-    let client = Client::new_for_root(root).await?;
+    let client = Client::new(root).await?;
 
     for pkg in pkgs {
         let lookup = name_to_provider(&pkg);

--- a/moss/src/cli/install.rs
+++ b/moss/src/cli/install.rs
@@ -2,9 +2,9 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-use clap::{arg, ArgMatches, Command};
+use clap::{arg, value_parser, ArgMatches, Command};
 use futures::{future::join_all, StreamExt};
 use moss::{
     client::{self, Client},
@@ -22,7 +22,16 @@ pub fn command() -> Command {
     Command::new("install")
         .about("Install packages")
         .long_about("Install the requested software to the local system")
-        .arg(arg!(<NAME> ... "packages to install").value_parser(clap::value_parser!(String)))
+        .arg(arg!(<NAME> ... "packages to install").value_parser(value_parser!(String)))
+        .arg(
+            arg!(--to <blit_target> "Blit this install to the provided directory instead of the root")
+                .long_help(
+                    "Blit this install to the provided directory instead of the root. \n\
+                     \n\
+                     This operation won't be captured as a new state",
+                )
+                .value_parser(value_parser!(PathBuf)),
+        )
 }
 
 /// Handle execution of `moss install`
@@ -35,8 +44,12 @@ pub async fn handle(args: &ArgMatches, root: &Path) -> Result<(), Error> {
         .collect::<Vec<_>>();
 
     // Grab a client for the root
-    let client = Client::new(root).await?;
-    let active_state = client.installation.active_state;
+    let mut client = Client::new(root).await?;
+
+    // Make ephemeral if a blit target was provided
+    if let Some(blit_target) = args.get_one::<PathBuf>("to").cloned() {
+        client = client.ephemeral(blit_target)?;
+    }
 
     // Resolve input packages
     let input = resolve_input(pkgs, &client).await?;
@@ -49,10 +62,13 @@ pub async fn handle(args: &ArgMatches, root: &Path) -> Result<(), Error> {
     // Resolve transaction to metadata
     let resolved = client.resolve_packages(tx.finalize()).await?;
 
-    // Get missing packages that aren't installed
+    // Get missing packages that are:
+    //
+    // Stateful: Not installed
+    // Ephemeral: all
     let missing = resolved
         .iter()
-        .filter(|p| !p.is_installed())
+        .filter(|p| client.is_ephemeral() || !p.is_installed())
         .collect::<Vec<_>>();
 
     // If no new packages exist, exit and print
@@ -87,9 +103,10 @@ pub async fn handle(args: &ArgMatches, root: &Path) -> Result<(), Error> {
 
     // Calculate the new state of packages (old_state + missing)
     let new_state_pkgs = {
-        let previous_selections = match active_state {
-            Some(id) => client.state_db.get(&id).await?.selections,
-            None => vec![],
+        // Only use previous state in stateful mode
+        let previous_selections = match client.installation.active_state {
+            Some(id) if !client.is_ephemeral() => client.state_db.get(&id).await?.selections,
+            _ => vec![],
         };
         let missing_selections = missing.iter().map(|p| Selection {
             package: p.id.clone(),

--- a/moss/src/cli/install.rs
+++ b/moss/src/cli/install.rs
@@ -35,7 +35,7 @@ pub async fn handle(args: &ArgMatches, root: &Path) -> Result<(), Error> {
         .collect::<Vec<_>>();
 
     // Grab a client for the root
-    let client = Client::new_for_root(root).await?;
+    let client = Client::new(root).await?;
     let active_state = client.installation.active_state;
 
     // Resolve input packages

--- a/moss/src/cli/list.rs
+++ b/moss/src/cli/list.rs
@@ -63,7 +63,7 @@ pub async fn handle(args: &ArgMatches) -> Result<(), Error> {
     };
 
     // Grab a client for the target, enumerate packages
-    let client = Client::new_for_root(root).await?;
+    let client = Client::new(root).await?;
     let pkgs = client.registry.list(filter_flags).collect::<Vec<_>>().await;
 
     let sync_available = if sync.is_some() {

--- a/moss/src/cli/remove.rs
+++ b/moss/src/cli/remove.rs
@@ -35,7 +35,7 @@ pub async fn handle(args: &ArgMatches, root: &Path) -> Result<(), Error> {
         .collect::<Vec<_>>();
 
     // Grab a client for the target, enumerate packages
-    let client = Client::new_for_root(root).await?;
+    let client = Client::new(root).await?;
 
     let installed = client
         .registry

--- a/moss/src/cli/state.rs
+++ b/moss/src/cli/state.rs
@@ -39,7 +39,7 @@ pub async fn handle(args: &ArgMatches, root: &Path) -> Result<(), Error> {
 
 /// List all known states, newest first
 pub async fn list(root: &Path) -> Result<(), Error> {
-    let client = Client::new_for_root(root).await?;
+    let client = Client::new(root).await?;
 
     let state_ids = client.state_db.list_ids().await?;
 
@@ -56,7 +56,7 @@ pub async fn list(root: &Path) -> Result<(), Error> {
 pub async fn prune(args: &ArgMatches, root: &Path) -> Result<(), Error> {
     let keep = *args.get_one::<u64>("keep").unwrap();
 
-    let client = Client::new_for_root(root).await?;
+    let client = Client::new(root).await?;
     client.prune(prune::Strategy::KeepRecent(keep)).await?;
 
     Ok(())

--- a/moss/src/cli/version.rs
+++ b/moss/src/cli/version.rs
@@ -3,8 +3,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use clap::Command;
-
-const VERSION: &str = env!("CARGO_PKG_VERSION");
+use moss::environment;
 
 /// Construct the Version command
 pub fn command() -> Command {
@@ -13,5 +12,5 @@ pub fn command() -> Command {
 
 /// Print program version
 pub fn print() {
-    println!("moss {VERSION}");
+    println!("moss {}", environment::VERSION);
 }

--- a/moss/src/environment.rs
+++ b/moss/src/environment.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// Max concurrency for disk tasks
 pub const MAX_DISK_CONCURRENCY: usize = 16;
 /// Max concurrency for network tasks

--- a/moss/src/state.rs
+++ b/moss/src/state.rs
@@ -10,8 +10,14 @@ use tui::{pretty, Stylize};
 use crate::package;
 
 /// Unique identifier for [`State`]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct Id(i64);
+
+impl Id {
+    pub fn next(self) -> Self {
+        Self(self.0 + 1)
+    }
+}
 
 impl From<i64> for Id {
     fn from(id: i64) -> Self {

--- a/vfs/src/tree/mod.rs
+++ b/vfs/src/tree/mod.rs
@@ -98,11 +98,24 @@ impl<T: BlitFile> Tree<T> {
                 })
                 .collect::<Vec<_>>();
             if !others.is_empty() {
-                Err(Error::Duplicate(
-                    node.get().path(),
-                    node.get().id(),
-                    others.first().unwrap().id(),
-                ))
+                // TODO: Reenable
+                // Err(Error::Duplicate(
+                //     node.get().path(),
+                //     node.get().id(),
+                //     others.first().unwrap().id(),
+                // ))
+
+                // Report duplicate and skip for now
+                eprintln!(
+                    "error: {}",
+                    Error::Duplicate(
+                        node.get().path(),
+                        node.get().id(),
+                        others.first().unwrap().id(),
+                    )
+                );
+
+                Ok(())
             } else {
                 parent_node.append(node_id, &mut self.arena);
                 Ok(())


### PR DESCRIPTION
`--to` on `sync` / `install` will output the blit to a custom target folder without recording any state. `sync` outputs the current state. `install` outputs _only_ the packages passed via `install`, which is nice for building ad-hoc container roots.