### PR TITLE
Add workflow for nightly builds

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -78,3 +78,4 @@ jobs:
         tag: nightly-${{ steps.get_date.outputs.date }}
         overwrite: true
         prerelease: true
+        release_name: "Nightly release ${{ steps.get_date.outputs.date }}"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@nightly
 
     - name: Cargo Cache
       uses: actions/cache@v3

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -42,10 +42,10 @@ jobs:
     - name: Build project
       run: |
         cargo +nightly -Z build-std=std build --target=x86_64-unknown-linux-musl --profile packaging
-        mkdir release
         strip target/x86_64-unknown-linux-musl/packaging/moss
-        tar czvf release/moss.tar.gz -C target/x86_64-unknown-linux-musl/packaging moss
-        sha256sum release/moss.tar.gz > release/moss_sha256sum.txt
+        mkdir release && cd release
+        tar czvf moss.tar.gz -C ../target/x86_64-unknown-linux-musl/packaging moss
+        sha256sum moss.tar.gz > moss_sha256sum.txt
 
     - name: Generate tag
       run: |
@@ -79,3 +79,4 @@ jobs:
         overwrite: true
         prerelease: true
         release_name: "Nightly release ${{ steps.get_date.outputs.date }}"
+        body: "Nightly release of moss"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -19,6 +19,9 @@ jobs:
     - name: Checkout source
       uses: actions/checkout@v3
 
+    - name: Install musl
+      run: sudo apt-get install musl-tools
+
     - name: Install Rust
       uses: dtolnay/rust-toolchain@nightly
       with:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -38,4 +38,4 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Build project
-      run: cargo +nightly -Z build-std=std build --target=x86_64-unknown-linux-musl --profile packaging; ls -la; strip moss-rs; ls -la
+      run: cargo +nightly -Z build-std=std build --target=x86_64-unknown-linux-musl --profile packaging; ls -la target/x86_64-unknown-linux-musl/packaging; strip target/x86_64-unknown-linux-musl/packaging/moss; ls -la target/x86_64-unknown-linux-musl/packaging

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -23,6 +23,7 @@ jobs:
       uses: dtolnay/rust-toolchain@nightly
       with:
         targets: x86_64-unknown-linux-musl
+        components: rust-src
 
     - name: Cargo Cache
       uses: actions/cache@v3

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -6,6 +6,8 @@ on:
   schedule:
     - cron: '0 1 * * *'
   workflow_dispatch:
+permissions:
+  contents: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -38,4 +40,33 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Build project
-      run: cargo +nightly -Z build-std=std build --target=x86_64-unknown-linux-musl --profile packaging; ls -la target/x86_64-unknown-linux-musl/packaging; strip target/x86_64-unknown-linux-musl/packaging/moss; ls -la target/x86_64-unknown-linux-musl/packaging
+      run: |
+        cargo +nightly -Z build-std=std build --target=x86_64-unknown-linux-musl --profile packaging
+        mkdir release
+        strip target/x86_64-unknown-linux-musl/packaging/moss -o release/moss
+        sha256sum target/x86_64-unknown-linux-musl/packaging/moss > release/moss_sha256sum.txt
+        ls -la release
+
+    # - name: Bump version and push tag
+    #   id: tag_version
+    #   uses: mathieudutour/github-tag-action@v6.1
+    #   with:
+    #     github_token: ${{ secrets.GITHUB_TOKEN }}
+
+    # - name: 'Clean up nightly releases'
+    #   uses: dev-drprasad/delete-older-releases@v0.3.2
+    #   with:
+    #     keep_latest: 5
+    #     delete_tags: true
+    #     delete_tag_pattern: nightly
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # - name: Upload binaries to nightly release
+    #   uses: svenstaro/upload-release-action@v2
+    #   with:
+    #     repo_token: ${{ secrets.GITHUB_TOKEN }}
+    #     file: release/mos*
+    #     file_glob: true
+    #     tag: ${{ github.ref }}
+    #     overwrite: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -75,6 +75,6 @@ jobs:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: release/moss*
         file_glob: true
-        tag: ${{ github.ref }}
+        tag: nightly-${{ steps.get_date.outputs.date }}
         overwrite: true
         prerelease: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,10 +1,8 @@
 name: Nightly Build
 
 on:
-  pull_request:
-    branches: [ "main" ]
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
 permissions:
   contents: write
@@ -13,9 +11,9 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  nightly:
     runs-on: ubuntu-latest
-    name: Build & Test Project
+    name: Build nightly release
 
     steps:
     - name: Checkout source
@@ -45,7 +43,7 @@ jobs:
         strip target/x86_64-unknown-linux-musl/packaging/moss
         mkdir release && cd release
         tar czvf moss.tar.gz -C ../target/x86_64-unknown-linux-musl/packaging moss
-        sha256sum moss.tar.gz > moss_sha256sum.txt
+        sha256sum moss.tar.gz > moss.tar.gz.sha256
 
     - name: Generate tag
       run: |
@@ -60,15 +58,6 @@ jobs:
         custom_tag: ${{ steps.get_date.outputs.date }}
         tag_prefix: nightly-
 
-    - name: Clean up nightly releases
-      uses: dev-drprasad/delete-older-releases@v0.3.2
-      with:
-        keep_latest: 5
-        delete_tags: true
-        delete_tag_pattern: nightly
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Upload binaries to nightly release
       uses: svenstaro/upload-release-action@v2
       with:
@@ -80,3 +69,12 @@ jobs:
         prerelease: true
         release_name: "Nightly release ${{ steps.get_date.outputs.date }}"
         body: "Nightly release of moss"
+
+    - name: Clean up old nightly releases
+      uses: dev-drprasad/delete-older-releases@v0.3.2
+      with:
+        keep_latest: 5
+        delete_tags: true
+        delete_tag_pattern: nightly
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -44,30 +44,37 @@ jobs:
         cargo +nightly -Z build-std=std build --target=x86_64-unknown-linux-musl --profile packaging
         mkdir release
         strip target/x86_64-unknown-linux-musl/packaging/moss
-        sha256sum target/x86_64-unknown-linux-musl/packaging/moss > release/moss_sha256sum.txt
         tar czvf release/moss.tar.gz -C target/x86_64-unknown-linux-musl/packaging moss
+        sha256sum release/moss.tar.gz > release/moss_sha256sum.txt
 
-    - name: Bump version and push tag
-      id: tag_version
+    - name: Generate tag
+      run: |
+        echo "date=$(date '+%Y%m%d-%H%M%S')" >> $GITHUB_OUTPUT
+      id: get_date
+
+    - name: Push nightly tag
       uses: mathieudutour/github-tag-action@v6.1
+      id: create_tag
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        custom_tag: nightly-
+        custom_tag: ${{ steps.get_date.outputs.date }}
+        tag_prefix: nightly-
 
-    # - name: 'Clean up nightly releases'
-    #   uses: dev-drprasad/delete-older-releases@v0.3.2
-    #   with:
-    #     keep_latest: 5
-    #     delete_tags: true
-    #     delete_tag_pattern: nightly
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Clean up nightly releases
+      uses: dev-drprasad/delete-older-releases@v0.3.2
+      with:
+        keep_latest: 5
+        delete_tags: true
+        delete_tag_pattern: nightly
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    # - name: Upload binaries to nightly release
-    #   uses: svenstaro/upload-release-action@v2
-    #   with:
-    #     repo_token: ${{ secrets.GITHUB_TOKEN }}
-    #     file: release/mos*
-    #     file_glob: true
-    #     tag: ${{ github.ref }}
-    #     overwrite: true
+    - name: Upload binaries to nightly release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: release/moss*
+        file_glob: true
+        tag: ${{ github.ref }}
+        overwrite: true
+        prerelease: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -21,6 +21,8 @@ jobs:
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@nightly
+      with:
+        targets: x86_64-unknown-linux-musl
 
     - name: Cargo Cache
       uses: actions/cache@v3

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -43,16 +43,16 @@ jobs:
       run: |
         cargo +nightly -Z build-std=std build --target=x86_64-unknown-linux-musl --profile packaging
         mkdir release
-        strip target/x86_64-unknown-linux-musl/packaging/moss -o release/moss
+        strip target/x86_64-unknown-linux-musl/packaging/moss
         sha256sum target/x86_64-unknown-linux-musl/packaging/moss > release/moss_sha256sum.txt
-        tar czvf release/moss.tar.gz release/moss
-        ls -la release
+        tar czvf release/moss.tar.gz -C target/x86_64-unknown-linux-musl/packaging moss
 
-    # - name: Bump version and push tag
-    #   id: tag_version
-    #   uses: mathieudutour/github-tag-action@v6.1
-    #   with:
-    #     github_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Bump version and push tag
+      id: tag_version
+      uses: mathieudutour/github-tag-action@v6.1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        custom_tag: nightly-
 
     # - name: 'Clean up nightly releases'
     #   uses: dev-drprasad/delete-older-releases@v0.3.2

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,35 @@
+name: Nightly Build
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build & Test Project
+
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v3
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cargo Cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Build project
+      run: cargo +nightly -Z build-std=std build --target=x86_64-unknown-linux-musl --profile packaging; ls -la; strip moss-rs; ls -la

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -45,6 +45,7 @@ jobs:
         mkdir release
         strip target/x86_64-unknown-linux-musl/packaging/moss -o release/moss
         sha256sum target/x86_64-unknown-linux-musl/packaging/moss > release/moss_sha256sum.txt
+        tar czvf release/moss.tar.gz release/moss
         ls -la release
 
     # - name: Bump version and push tag


### PR DESCRIPTION
Creates releases with a binary of latest moss:
https://github.com/serpent-os/moss-rs/releases/tag/nightly-20231121-164115
Also only keeps the last 5 versions.