### PR TITLE
Update checkout action to v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Checkout source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install musl
       run: sudo apt-get install musl-tools


### PR DESCRIPTION
[Makes it run with Nodejs 20 instead of 16](https://github.com/actions/checkout/blob/v4/CHANGELOG.md#v400)