### PR TITLE
Add repo remove command

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -96,6 +96,17 @@ impl Manager {
 
         Ok(())
     }
+
+    pub async fn delete<T: Config>(&self, name: impl fmt::Display) -> Result<(), io::Error> {
+        let domain = T::domain();
+
+        let dir = self.scope.save_dir(&domain);
+        let path = dir.join(format!("{name}.{EXTENSION}"));
+
+        fs::remove_file(&path).await?;
+
+        Ok(())
+    }
 }
 
 #[derive(Debug, Error)]

--- a/crates/moss/src/repository/mod.rs
+++ b/crates/moss/src/repository/mod.rs
@@ -22,6 +22,7 @@ pub mod manager;
 
 /// A unique [`Repository`] identifier
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(from = "String")]
 pub struct Id(String);
 
 impl Id {
@@ -38,6 +39,12 @@ impl Id {
 impl fmt::Display for Id {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+impl From<String> for Id {
+    fn from(value: String) -> Self {
+        Self::new(value)
     }
 }
 


### PR DESCRIPTION
Add `repo remove` CLI option

Note that since our config format allows any config file to hold a map of entries, this command only succeeds if the config for the repo is in it's own config file w/ matching repo name. Otherwise it prompts user to manually delete the config.