### PR TITLE
Ensure all repos are initialized

### DIFF
--- a/crates/boulder/src/cli/profile.rs
+++ b/crates/boulder/src/cli/profile.rs
@@ -137,10 +137,8 @@ pub async fn update<'a>(
 ) -> Result<(), Error> {
     let repos = manager.repositories(profile)?.clone();
 
-    let mut moss_client = moss::Client::new("boulder", &env.moss_dir)
-        .await?
-        .explicit_repositories(repos)
-        .await?;
+    let mut moss_client =
+        moss::Client::with_explicit_repositories("boulder", &env.moss_dir, repos).await?;
     moss_client.refresh_repositories().await?;
 
     Ok(())

--- a/crates/boulder/src/root.rs
+++ b/crates/boulder/src/root.rs
@@ -17,11 +17,10 @@ pub async fn populate(builder: &Builder, repositories: repository::Map) -> Resul
     // Recreate root
     util::recreate_dir(&rootfs).await?;
 
-    let mut moss_client = moss::Client::new("boulder", &builder.env.moss_dir)
-        .await?
-        .explicit_repositories(repositories)
-        .await?
-        .ephemeral(&rootfs)?;
+    let mut moss_client =
+        moss::Client::with_explicit_repositories("boulder", &builder.env.moss_dir, repositories)
+            .await?
+            .ephemeral(&rootfs)?;
 
     moss_client.install(&packages, true).await?;
 


### PR DESCRIPTION
When user adds repos manually via config and not via moss or boulder CLI, the repo will be uninitialized and dependent commands will fail.

This ensures all configured repos are initialized when running moss client