### PR TITLE
Default boulder profiles

### DIFF
--- a/crates/boulder/data/profile.d/default-x86_64.yaml
+++ b/crates/boulder/data/profile.d/default-x86_64.yaml
@@ -1,0 +1,16 @@
+default-x86_64:
+  collections:
+      volatile:
+        uri: "https://dev.serpentos.com/volatile/x86_64/stone.index"
+        description: "Volatile moss repo"
+        priority: 0
+local-x86_64:
+  collections:
+      volatile:
+        uri: "https://dev.serpentos.com/volatile/x86_64/stone.index"
+        description: "Volatile moss repo"
+        priority: 0
+      local:
+        uri: "file:///var/cache/boulder/repos/local-x86_64/stone.index"
+        description: "Local development moss repo"
+        priority: 10

--- a/crates/boulder/src/cli/build.rs
+++ b/crates/boulder/src/cli/build.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 #[derive(Debug, Parser)]
 #[command(about = "Build ... TODO")]
 pub struct Command {
-    #[arg(short, long)]
+    #[arg(short, long, default_value = "default-x86_64")]
     profile: profile::Id,
     #[arg(
         short,

--- a/crates/boulder/src/cli/profile.rs
+++ b/crates/boulder/src/cli/profile.rs
@@ -143,6 +143,8 @@ pub async fn update<'a>(
         .await?;
     moss_client.refresh_repositories().await?;
 
+    println!("Profile {profile} updated");
+
     Ok(())
 }
 #[derive(Debug, Error)]

--- a/crates/boulder/src/cli/profile.rs
+++ b/crates/boulder/src/cli/profile.rs
@@ -39,7 +39,7 @@ pub enum Subcommand {
     },
     #[command(about = "Update a profiles repositories")]
     Update {
-        #[arg(short, long)]
+        #[arg(short, long, default_value = "default-x86_64")]
         profile: profile::Id,
     },
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -213,8 +213,43 @@ impl Scope {
                     },
                 ),
             ],
+            // System (root = "/") + User
             Scope::User { config, program } => {
+                let root = Path::new("/");
+
                 vec![
+                    (
+                        Entry::File,
+                        Resolve::System {
+                            root,
+                            base: SystemBase::Vendor,
+                            program,
+                        },
+                    ),
+                    (
+                        Entry::Directory,
+                        Resolve::System {
+                            root,
+                            base: SystemBase::Vendor,
+                            program,
+                        },
+                    ),
+                    (
+                        Entry::File,
+                        Resolve::System {
+                            root,
+                            base: SystemBase::Admin,
+                            program,
+                        },
+                    ),
+                    (
+                        Entry::Directory,
+                        Resolve::System {
+                            root,
+                            base: SystemBase::Admin,
+                            program,
+                        },
+                    ),
                     (Entry::File, Resolve::User { config, program }),
                     (Entry::Directory, Resolve::User { config, program }),
                 ]

--- a/crates/moss/src/repository/mod.rs
+++ b/crates/moss/src/repository/mod.rs
@@ -29,7 +29,13 @@ impl Id {
         Self(
             identifier
                 .chars()
-                .map(|c| if c.is_alphanumeric() { c } else { '_' })
+                .map(|c| {
+                    if c.is_alphanumeric() || c == '-' {
+                        c
+                    } else {
+                        '_'
+                    }
+                })
                 .collect(),
         )
     }


### PR DESCRIPTION
Support merging system config files w/ user config files and add default profile to data dir that packagers can ship boulder with and use as default profile when invoking applicable boulder commands