### PR TITLE
print help when the only argument is --directory

### DIFF
--- a/crates/moss/src/cli/mod.rs
+++ b/crates/moss/src/cli/mod.rs
@@ -86,6 +86,10 @@ pub async fn process() -> Result<(), Error> {
             version::print();
             Ok(())
         }
+        None => {
+            command().print_help().unwrap();
+            Ok(())
+        }
         _ => unreachable!(),
     }
 }


### PR DESCRIPTION
This should fix issue #111 where the cli panics with supplied with --directory but no subcommand.  If no subcommand is specified, moss now defaults to printing help rather than panics  