### PR TITLE
Print leading zeroes for hashes

### DIFF
--- a/crates/moss/src/cli/inspect.rs
+++ b/crates/moss/src/cli/inspect.rs
@@ -110,7 +110,7 @@ async fn inspect(paths: Vec<PathBuf>) -> Result<(), Error> {
                 for layout in layouts {
                     match layout.entry {
                         layout::Entry::Regular(hash, target) => {
-                            println!("    - /usr/{} - [Regular] {:02x}", target, hash)
+                            println!("    - /usr/{} - [Regular] {:032x}", target, hash)
                         }
                         layout::Entry::Directory(target) => {
                             println!("    - /usr/{} [Directory]", target)


### PR DESCRIPTION
I just randomly noticed that the shown hashes for the layout output are incorrect, for some files at least. Seems like leading zeroes for a hash aren't printed, so the length of the hash is < 32 chars.

Examples (only showing some affected lines):

```
$ target/debug/moss inspect test/bash-completion-2.11-1-1-x86_64.stone
Layout entries       :
    - /usr/share/bash-completion/completions/_mock - [Regular] 643ff65bbfaea9eeb0501febff14e5c
    - /usr/share/bash-completion/completions/_mount.linux - [Regular] 9e284063682c78bdef54eba751f7a8
    - /usr/share/bash-completion/completions/_nmcli - [Regular] a6a4317c64df97d84be1f53e3d75007
    - /usr/share/bash-completion/completions/apt-build - [Regular] 161f224b130cbf8b14ffaf36a23a5e5
    - /usr/share/bash-completion/completions/cfrun - [Regular] fb8bf6c7a525f622a813228dc22ed26
    - /usr/share/bash-completion/completions/cppcheck - [Regular] a88fff7a6408ea576d9fba6ad342009
    - /usr/share/bash-completion/completions/geoiplookup - [Regular] 7612982fcfb325e6014309a33d3bb9a
    - /usr/share/bash-completion/completions/gpgv - [Regular] 1b71417c190f18adb1d1d8bf4363656
    - /usr/share/bash-completion/completions/htop - [Regular] 3c7ace52ae5b018e29fdf58c723338c
    - /usr/share/bash-completion/completions/iconv - [Regular] b85189e1e2e4e3929535224581c4c4c
    - /usr/share/bash-completion/completions/jar - [Regular] d833261ae8244d5913228208d7c6125
    - /usr/share/bash-completion/completions/jpegoptim - [Regular] c8e81f229742779cd0b4757b59bf92e
    - /usr/share/bash-completion/completions/jps - [Regular] 3da7c17935d9ed48173c2630232c360
    - /usr/share/bash-completion/completions/ldapvi - [Regular] b9a3ef5f5e7e968e123618e9320b221
    - /usr/share/bash-completion/completions/make - [Regular] bd768be8b506b4b921d88560786d88b
    - /usr/share/bash-completion/completions/minicom - [Regular] 125d6ca120b1a76cacf610b2d66befd
    - /usr/share/bash-completion/completions/mktemp - [Regular] 1b45fd7e63549f6bf286ae434906487
    - /usr/share/bash-completion/completions/mmsitepass - [Regular] 3e0e3c4ef2c92e57169ce83d54106bf
    - /usr/share/bash-completion/completions/mypy - [Regular] 5052df91e2f13003bb7e1d6290ddfff
    - /usr/share/bash-completion/completions/p4 - [Regular] 4a0cd5ada61f7ea4f9e47228651fca7
    - /usr/share/bash-completion/completions/pkg-get - [Regular] b1c79bf10c9a491b42ceab955c4973d
    - /usr/share/bash-completion/completions/pngfix - [Regular] c7bba8d8361686c2c87193d63ea54aa
    - /usr/share/bash-completion/completions/rdesktop - [Regular] e41febb60fd1302c515bd6cb80f7ce1
    - /usr/share/bash-completion/completions/rpcdebug - [Regular] fa2368fd451d7a1c011651d6a293a65
    - /usr/share/bash-completion/completions/sbopkg - [Regular] 7334c036603062d03fd08d2187ff8fc
    - /usr/share/bash-completion/completions/shellcheck - [Regular] 461d62ddf9463696287d07e5d2ee449
    - /usr/share/bash-completion/completions/snownews - [Regular] c46ef3e9757d19a52b47e570fc59f4a
    - /usr/share/bash-completion/completions/ssh - [Regular] bccf23bc5e8e92b3d0ee124ebd470df
    - /usr/share/bash-completion/completions/sudo - [Regular] a7923c1010111f5574738ef6e9a7ba8
    - /usr/share/bash-completion/completions/tshark - [Regular] 525384d25ba415aaa38615a3a556aa3
    - /usr/share/bash-completion/completions/unshunt - [Regular] 2ec05408f357fb5b6a1bc0d254c5fa9
    - /usr/share/bash-completion/completions/xdg-settings - [Regular] 6d19837bbc6df1b75859fe0c1ef49a3
    - /usr/share/bash-completion/completions/xxd - [Regular] d3fc950d3cb98eb1db4d448e73b2037
    - /usr/share/cmake/bash-completion/bash-completion-config.cmake - [Regular] 99d9990c4a3c70dd5a8adf383922e6d1
```

Not sure if someone just missed the `3` or if it needs a nicer fix like `length(hash)` or whatever.