### PR TITLE
repo: Release improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ target
 install
 
 **/db/**/test.db
+
+# Generated source archives
+*.tar.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /target
 target
+/install
+install
 
 **/db/**/test.db

--- a/justfile
+++ b/justfile
@@ -124,3 +124,6 @@ install-moss:
 
   # Cleanup
   rm -rfv $tmpdir
+
+create-release-tar:
+  scripts/create-release-tar.sh

--- a/justfile
+++ b/justfile
@@ -6,6 +6,8 @@ build-mode := env_var_or_default("MODE", "onboarding")
 # Keep it simple for now and make installs user-local
 xdg-data-home := "$HOME/.local/share"
 xdg-bin-home := "$HOME/.local/bin"
+# Prefix for install tasks
+prefix := "./install"
 
 [private]
 help:
@@ -77,3 +79,48 @@ diesel db +ARGS:
     --config-file {{root-dir}}/moss/src/db/{{db}}/diesel.toml \
     --database-url sqlite://{{root-dir}}/moss/src/db/{{db}}/test.db \
     {{ARGS}}
+
+install-all: install-boulder install-moss
+
+install-boulder:
+  #!/usr/bin/env bash
+  set -euxo pipefail
+  install -Dm00755 target/{{ build-mode }}/boulder -t {{ prefix }}/usr/bin/
+
+  # Install all the data files
+  find boulder/data/ -type f -print0 | sed 's|boulder/data||g' | xargs -0 -I ? xargs install -Dm00644 boulder/data/? {{ prefix }}/usr/share/boulder/?
+
+  # Install shell completions
+  export tmpdir=`mktemp -d`
+  target/{{ build-mode }}/boulder completions bash > $tmpdir/boulder
+  install -Dm00644 $tmpdir/boulder -t {{ prefix }}/usr/share/bash-completion/completions/
+  target/{{ build-mode }}/boulder completions zsh > $tmpdir/_boulder
+  install -Dm00644 $tmpdir/_boulder -t {{ prefix }}/usr/share/zsh/site-functions/
+  target/{{ build-mode }}/boulder completions fish > $tmpdir/boulder.fish
+  install -Dm00644 $tmpdir/boulder.fish -t {{ prefix }}/usr/share/fish/vendor_completions.d/
+
+  # License
+  install -Dm00644 LICENSES/* -t {{ prefix }}/usr/share/licenses/boulder
+
+  # Cleanup
+  rm -rfv $tmpdir
+
+install-moss:
+  #!/usr/bin/env bash
+  set -euxo pipefail
+  install -Dm00755 target/{{ build-mode }}/moss -t {{ prefix }}/usr/bin/
+
+  # Install shell completions
+  export tmpdir=`mktemp -d`
+  target/{{ build-mode }}/moss completions bash > $tmpdir/moss
+  install -Dm00644 $tmpdir/moss -t {{ prefix }}/usr/share/bash-completion/completions/
+  target/{{ build-mode }}/moss completions zsh > $tmpdir/_moss
+  install -Dm00644 $tmpdir/_moss -t {{ prefix }}/usr/share/zsh/site-functions/
+  target/{{ build-mode }}/moss completions fish > $tmpdir/moss.fish
+      install -Dm00644 $tmpdir/moss.fish -t {{ prefix }}/usr/share/fish/vendor_completions.d/
+
+  # License
+  install -Dm00644 LICENSES/* -t {{ prefix }}/usr/share/licenses/moss
+
+  # Cleanup
+  rm -rfv $tmpdir

--- a/scripts/create-release-tar.sh
+++ b/scripts/create-release-tar.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Script to generate a tarball of source code and vendored (downloaded) Rust dependencies
+# and the cargo configuration to ensure they are used
+
+# Get the current directory, which we'll use for telling Cargo where to find the sources
+wd="$PWD"
+
+# Get the version from Cargo.toml
+VERSION=$(yq -oy '.workspace.package.version' Cargo.toml)
+
+# The path where we will output the tar file
+path=$wd/moss-$VERSION-vendored.tar.zst
+
+# Clean up stuff we've written before
+rm -f "$path"
+
+# Make sure cargo lock files are in sync with cargo.toml
+cargo check --locked
+
+PREFIX_TMPDIR=$(mktemp -d)
+pushd "$PREFIX_TMPDIR"
+
+# Enable dotglob so we copy over files/folders starting with .
+shopt -s dotglob
+cp -ra "$wd"/* .
+
+function get_commit_time() {
+  TZ=UTC0 git log -1 \
+    --format=tformat:%cd \
+    --date=format:%Y-%m-%dT%H:%M:%SZ \
+    "$@"
+}
+
+# Set each file mtime to that of it's latest commit
+# Set each source file timestamp to that of its latest commit.
+git ls-files | while read -r file; do
+  commit_time=$(get_commit_time "$file") &&
+  touch -md "$commit_time" "$file"
+done
+
+# Set timestamp of each directory under $FILES
+# to the latest timestamp of any descendant.
+find . -depth -type d -exec sh -c \
+  'touch -r "$0/$(ls -At "$0" | head -n 1)" "$0"' \
+  {} ';'
+
+SOURCE_EPOCH=$(get_commit_time)
+
+# Cleanup repo
+git reset --hard
+git clean -xdf
+git clean -df
+rm -rf .git
+rm -rf serpent-style
+
+# Generate vendored dependencies and the configuration to use them
+cargo vendor --manifest-path "$wd/Cargo.toml" >> .cargo/config.toml
+
+# vendoring drags in a lot of Windows dependencies, which makes the resulting tarball enormous
+# cargo can't be told only to support a particular platform
+# see https://github.com/rust-lang/cargo/issues/7058
+# workaround below from https://github.com/rust-lang/cargo/issues/7058#issuecomment-751856262
+rm -r vendor/winapi*/lib/*.a
+
+# Reproducible tar flags
+TARFLAGS="
+  --sort=name --format=posix
+  --pax-option=exthdr.name=%d/PaxHeaders/%f
+  --pax-option=delete=atime,delete=ctime
+  --clamp-mtime --mtime=$SOURCE_EPOCH
+  --numeric-owner --owner=0 --group=0
+  --mode=go+u,go-w
+"
+ZSTDFLAGS="-19 -T0"
+
+# shellcheck disable=SC2086
+LC_ALL=C tar $TARFLAGS -C $PREFIX_TMPDIR -cf  - . |
+  zstd $ZSTDFLAGS > $path
+
+popd
+rm -rf "$PREFIX_TMPDIR"
+
+checksum=$(sha256sum "$path")
+echo "Release tar checksum $checksum"


### PR DESCRIPTION
The first commit adds an install script to the justfile that installs all required files for boulder and moss into a given prefix, suitable for use during building packages. Note that the release script assumes that serpent-os/moss#239 has already been merged as it attempts to generate completions. I felt that that particular commit made more sense combined with this one.

The second commit adds a script to generate a vendored tarball containing source code plus vendored dependencies, suitable for use building packages without networking. This tarball is completely reproducible. 

To prove reproducibility, you can check out this branch and run the script yourself. It should output the following checksum, assuming your zstd version is v1.5.6:
```
624463d1acf9eab911eba1d631ee3c6b33aaae300a98a359c2d8528753a7e220
```