### PR TITLE
moss/boulder: Add support for font providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,7 @@ dependencies = [
  "itertools 0.13.0",
  "moss",
  "nix 0.27.1",
+ "read-fonts",
  "regex",
  "serde",
  "serde_json",
@@ -277,6 +278,26 @@ name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "bytemuck"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "102087e286b4677862ea56cf8fc58bb2cdfa8725c40ffb80fe3a008eb7f2fc83"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee891b04274a59bd38b412188e24b849617b2e45a0fd8d057deb63e7403761b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "bytes"
@@ -830,6 +851,15 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "font-types"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f0189ccb084f77c5523e08288d418cbaa09c451a08515678a0aa265df9a8b60"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -1756,6 +1786,16 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c141b9980e1150201b2a3a32879001c8f975fe313ec3df5471a9b5c79a880cd"
+dependencies = [
+ "bytemuck",
+ "font-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ tokio-util = { version = "0.7.11", features = ["io"] }
 url = { version = "2.5.2", features = ["serde"] }
 xxhash-rust = { version = "0.8.11", features = ["xxh3"] }
 zstd = { version = "0.13.2", features = ["zstdmt"] }
+read-fonts = "0.20.0"
 
 [profile.release]
 lto = "thin"

--- a/boulder/Cargo.toml
+++ b/boulder/Cargo.toml
@@ -43,3 +43,4 @@ strum.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 url.workspace = true
+read-fonts.workspace = true

--- a/boulder/src/package/analysis.rs
+++ b/boulder/src/package/analysis.rs
@@ -38,6 +38,7 @@ impl<'a> Chain<'a> {
                 Box::new(handler::elf),
                 Box::new(handler::pkg_config),
                 Box::new(handler::cmake),
+                Box::new(handler::font),
                 // Catch-all if not excluded
                 Box::new(handler::include_any),
             ],

--- a/crates/stone/src/payload/meta.rs
+++ b/crates/stone/src/payload/meta.rs
@@ -50,6 +50,9 @@ pub enum Dependency {
 
     /// An emul32-compatible pkgconfig .pc dependency (lib32/*.pc)
     PkgConfig32,
+
+    /// OpenType Font FAMILY_NAME
+    Font,
 }
 
 #[repr(u8)]
@@ -146,6 +149,7 @@ fn decode_dependency(i: u8) -> Result<Dependency, DecodeError> {
         6 => Dependency::Binary,
         7 => Dependency::SystemBinary,
         8 => Dependency::PkgConfig32,
+        9 => Dependency::Font,
         _ => return Err(DecodeError::UnknownDependency(i)),
     };
     Ok(result)

--- a/moss/src/dependency.rs
+++ b/moss/src/dependency.rs
@@ -59,6 +59,9 @@ pub enum Kind {
 
     /// Exported 32-bit pkgconfig provider
     PkgConfig32,
+
+    /// OpenType Font FAMILY_NAME
+    Font,
 }
 
 /// Convert payload dependency types to our internal representation
@@ -74,6 +77,7 @@ impl From<payload::meta::Dependency> for Kind {
             payload::meta::Dependency::Binary => Kind::Binary,
             payload::meta::Dependency::SystemBinary => Kind::SystemBinary,
             payload::meta::Dependency::PkgConfig32 => Kind::PkgConfig32,
+            payload::meta::Dependency::Font => Kind::Font,
         }
     }
 }
@@ -91,6 +95,7 @@ impl From<Kind> for payload::meta::Dependency {
             Kind::Binary => Self::Binary,
             Kind::SystemBinary => Self::SystemBinary,
             Kind::PkgConfig32 => Self::PkgConfig32,
+            Kind::Font => Self::Font,
         }
     }
 }


### PR DESCRIPTION
Reads FAMILY_NAME from OpenType fonts in order to provide a font provider.

e.g. `moss it 'font(Noto Sans Tamil Condensed Thin)'`