### PR TITLE
boulder: Use bsdtar-static

### DIFF
--- a/boulder/src/build/job/phase.rs
+++ b/boulder/src/build/job/phase.rs
@@ -253,17 +253,10 @@ fn prepare_script(upstreams: &[stone_recipe::Upstream]) -> String {
                 let strip_dirs = strip_dirs.unwrap_or(1);
 
                 let _ = writeln!(&mut content, "mkdir -p {unpack_dir}");
-                if rename.ends_with(".zip") {
-                    let _ = writeln!(
-                        &mut content,
-                        r#"unzip -d "{unpack_dir}" "%(sourcedir)/{rename}" || (echo "Failed to extract archive"; exit 1);"#,
-                    );
-                } else {
-                    let _ = writeln!(
-                        &mut content,
-                        r#"tar xf "%(sourcedir)/{rename}" -C "{unpack_dir}" --strip-components={strip_dirs} --no-same-owner || (echo "Failed to extract archive"; exit 1);"#,
-                    );
-                }
+                let _ = writeln!(
+                    &mut content,
+                    r#"bsdtar-static xf "%(sourcedir)/{rename}" -C "{unpack_dir}" --strip-components={strip_dirs} --no-same-owner || (echo "Failed to extract archive"; exit 1);"#,
+                );
             }
             stone_recipe::Upstream::Git { uri, clone_dir, .. } => {
                 let source = util::uri_file_name(uri);

--- a/boulder/src/build/root.rs
+++ b/boulder/src/build/root.rs
@@ -139,19 +139,22 @@ fn packages(builder: &Builder) -> Vec<&str> {
             if let Some((_, ext)) = path.rsplit_once('.') {
                 match ext {
                     "xz" => {
-                        packages.extend(["binary(tar)", "binary(xz)"]);
+                        packages.push("binary(bsdtar-static)");
                     }
                     "zst" => {
-                        packages.extend(["binary(tar)", "binary(zstd)"]);
+                        packages.push("binary(bsdtar-static)");
                     }
                     "bz2" => {
-                        packages.extend(["binary(tar)", "binary(bzip2)"]);
+                        packages.push("binary(bsdtar-static)");
                     }
                     "gz" => {
-                        packages.extend(["binary(tar)", "binary(gzip)"]);
+                        packages.push("binary(bsdtar-static)");
+                    }
+                    "lz" => {
+                        packages.push("binary(bsdtar-static)");
                     }
                     "zip" => {
-                        packages.push("binary(unzip)");
+                        packages.push("binary(bsdtar-static)");
                     }
                     "rpm" => {
                         packages.extend(["binary(rpm2cpio)", "cpio"]);

--- a/boulder/src/draft/upstream.rs
+++ b/boulder/src/draft/upstream.rs
@@ -84,25 +84,13 @@ async fn extract(archive: &Path, destination: &Path) -> Result<(), Error> {
     if let Some(kind) = infer::get_from_path(archive)? {
         println!("Detected type: {} ({})", kind.mime_type(), kind.extension());
         // If we can't specialise (.zip, etc) assume its a tar
-        let result = match kind.extension() {
-            "zip" => {
-                Command::new("unzip")
-                    .arg(archive)
-                    .arg("-d")
-                    .arg(destination)
-                    .output()
-                    .await?
-            }
-            _ => {
-                Command::new("tar")
-                    .arg("xf")
-                    .arg(archive)
-                    .arg("-C")
-                    .arg(destination)
-                    .output()
-                    .await?
-            }
-        };
+        let result = Command::new("bsdtar-static")
+            .arg("xf")
+            .arg(archive)
+            .arg("-C")
+            .arg(destination)
+            .output()
+            .await?;
         if result.status.success() {
             Ok(())
         } else {
@@ -111,7 +99,7 @@ async fn extract(archive: &Path, destination: &Path) -> Result<(), Error> {
         }
     } else {
         println!("Unknown file type, attempting tar extraction");
-        let result = Command::new("tar")
+        let result = Command::new("bsdtar-static")
             .arg("xf")
             .arg(archive)
             .arg("-C")


### PR DESCRIPTION
bsdtar-static is a special build of bsdtar that statically links libarchive, libxml, and libicu (https://github.com/AerynOS/recipes/commit/63f4f1fa67ae72eaa6a9d048bc0b1fbd5c4b282a). Use it instead of tar for extracting archives.

Note that bsdtar-static is also capable of handling .zip archives.