### PR TITLE
boulder: Add `%cargo_vendor` action macro

### DIFF
--- a/boulder/data/macros/actions/cargo.yaml
+++ b/boulder/data/macros/actions/cargo.yaml
@@ -16,6 +16,14 @@ actions:
         dependencies:
             - binary(cargo)
 
+    - cargo_vendor:
+        description: Vendor all dependencies
+        command: |
+            mkdir -pv ./.cargo
+            cargo vendor -v --locked >> ./.cargo/config.toml
+        dependencies:
+            - binary(cargo)
+
     - cargo_build:
         description: Build the rust project
         command: |


### PR DESCRIPTION
This enables packagers to lock dependencies for Rust-based packages.