### PR TITLE
boulder: Allow for skipping dbginfo entirely

### DIFF
--- a/boulder/src/package/analysis/handler/elf.rs
+++ b/boulder/src/package/analysis/handler/elf.rs
@@ -290,6 +290,10 @@ fn split_debug(
     bit_size: Class,
     build_id: &str,
 ) -> Result<Option<PathBuf>, BoxError> {
+    if !bucket.recipe.parsed.options.debug {
+        return Ok(None);
+    }
+
     let use_llvm = matches!(bucket.recipe.parsed.options.toolchain, Toolchain::Llvm);
     let objcopy = if use_llvm {
         "/usr/bin/llvm-objcopy"

--- a/crates/stone_recipe/src/lib.rs
+++ b/crates/stone_recipe/src/lib.rs
@@ -92,6 +92,8 @@ pub struct Options {
     #[serde(default, deserialize_with = "stringy_bool")]
     pub samplepgo: bool,
     #[serde(default = "default_true", deserialize_with = "stringy_bool")]
+    pub debug: bool,
+    #[serde(default = "default_true", deserialize_with = "stringy_bool")]
     pub strip: bool,
     #[serde(default, deserialize_with = "stringy_bool")]
     pub networking: bool,


### PR DESCRIPTION
The vscode extension signature verification requires that the binaries not be modified after building. `strip` prevents the debug info from being removed from binaries, but it doesn't prevent boulder from copying the debug info and adding a gnu.debuglink field to point to the debuginfo (thus modifying the binaries). Fix this by adding a new field that skips dbginfo generation entirely.