### PR TITLE
boulder: Add time elapsed and percentage complete to ninja status

### DIFF
--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -93,6 +93,7 @@ actions              :
             CCACHE_DIR="%(ccachedir)"; export CCACHE_DIR;
             CCACHE_BASEDIR="%(workdir)"; export CCACHE_BASEDIR
             test -z "$CCACHE_DIR" && unset CCACHE_DIR;
+            export NINJA_STATUS="[%%f/%%t %%es (%%P)] ";
             %cargo_set_environment
             RUSTC_WRAPPER="%(rustc_wrapper)"; export RUSTC_WRAPPER;
             test -z "$RUSTC_WRAPPER" && unset RUSTC_WRAPPER;


### PR DESCRIPTION
This adds the time elapsed (in seconds) as well as the estimated percentage complete (in runtime) to the ninja output. 

Basically the meson and cmake build output will look like this now:
```
[234/294 0.490s ( 79%)] clang -Itests ...
```