### PR TITLE
Ensure async runtime cannot outlive scope of running a future

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 target
 
 **/db/**/test.db
+
+.root

--- a/boulder/src/cli/build.rs
+++ b/boulder/src/cli/build.rs
@@ -11,7 +11,6 @@ use boulder::package::Packager;
 use boulder::{Env, Timing, container, package, profile, timing};
 use chrono::Local;
 use clap::Parser;
-use moss::runtime;
 use moss::signal::inhibit;
 use thiserror::Error;
 use thread_priority::{NormalThreadSchedulePolicy, ThreadPriority, ThreadSchedulePolicy, thread_native_id};
@@ -66,8 +65,6 @@ pub fn handle(command: Command, env: Env) -> Result<(), Error> {
         ..
     } = command;
 
-    let rt = runtime::init();
-
     let mut timing = Timing::default();
     let timer = timing.begin(timing::Kind::Initialize);
 
@@ -103,9 +100,6 @@ pub fn handle(command: Command, env: Env) -> Result<(), Error> {
         format!("Build in-progress: {pkg_name}"),
         "block".into(),
     );
-
-    // Ensure runtime is dropped before we enter the container
-    drop(rt);
 
     // Build & package from within container
     container::exec::<Error>(paths, networking, || {

--- a/boulder/src/cli/profile.rs
+++ b/boulder/src/cli/profile.rs
@@ -77,8 +77,6 @@ fn parse_repository(s: &str) -> Result<(repository::Id, Repository), String> {
 }
 
 pub fn handle(command: Command, env: Env) -> Result<(), Error> {
-    let _guard = runtime::init();
-
     let manager = profile::Manager::new(&env);
 
     match command.subcommand {

--- a/boulder/src/cli/recipe.rs
+++ b/boulder/src/cli/recipe.rs
@@ -146,9 +146,6 @@ fn bump(recipe: PathBuf, release: Option<u64>) -> Result<(), Error> {
 }
 
 fn new(output: PathBuf, upstreams: Vec<Url>, env: Env) -> Result<(), Error> {
-    // We use async to fetch upstreams
-    let _guard = runtime::init();
-
     const RECIPE_FILE: &str = "stone.yaml";
     const MONITORING_FILE: &str = "monitoring.yaml";
 
@@ -234,9 +231,6 @@ fn update(
             }
         }
     }
-
-    // Needed to fetch
-    let _guard = runtime::init();
 
     let mpb = MultiProgress::new();
 

--- a/moss/src/cli/mod.rs
+++ b/moss/src/cli/mod.rs
@@ -10,7 +10,7 @@ use clap_complete::{
     shells::{Bash, Fish, Zsh},
 };
 use clap_mangen::Man;
-use moss::{Installation, installation, runtime};
+use moss::{Installation, installation};
 use thiserror::Error;
 use tracing_common::{self, logging::LogConfig, logging::init_log_with_config};
 
@@ -190,9 +190,6 @@ pub fn process() -> Result<(), Error> {
 
     let root = matches.get_one::<PathBuf>("root").unwrap();
     let cache = matches.get_one::<PathBuf>("cache");
-
-    // Make async runtime available to all of moss
-    let _guard = runtime::init();
 
     let installation = Installation::open(root, cache.cloned())?;
 

--- a/moss/src/runtime.rs
+++ b/moss/src/runtime.rs
@@ -2,72 +2,16 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use std::{
-    future::Future,
-    io,
-    sync::{OnceLock, RwLock},
-};
+use std::future::Future;
 
 use tokio::runtime::{self, Handle};
 
-static RUNTIME: OnceLock<RwLock<Option<Runtime>>> = OnceLock::new();
-
-/// One-time initialisation of the tokio runtime
-pub fn init() -> Guard {
-    let lock = RUNTIME.get_or_init(Default::default);
-    *lock.write().unwrap() = Some(Runtime::new().expect("build runtime"));
-    Guard
-}
-
-/// Explicit destroy support for the runtime.
-/// This allows us to get rid of the runtime when multithreading is not desirable
-/// such as entering a [`container::Container`]
-fn destroy() {
-    let rt = RUNTIME
-        .get()
-        .unwrap()
-        .write()
-        .unwrap()
-        .take()
-        .expect("runtime initialized");
-    drop(rt);
-}
-
-/// The Guard provides a scoped token to utilise the Runtime
-#[must_use = "runtime is dropped with guard"]
-pub struct Guard;
-
-impl Drop for Guard {
-    fn drop(&mut self) {
-        destroy();
-    }
-}
-
-/// Lifetime management handle for the runtime
-struct Runtime(runtime::Runtime);
-
-impl Runtime {
-    /// Construct a new Runtime on the current thread
-    fn new() -> io::Result<Self> {
-        Ok(Self(runtime::Builder::new_current_thread().enable_all().build()?))
-    }
-}
-
-/// Run the provided future on the global runtime if it's
-/// been initialized, otherwise it creates a temporary runtime
-/// to run the future on and then fully drops it.
+/// Run the provided future on a single use runtime that
+/// is dropped before returning the completed task
 pub fn block_on<T, F>(task: F) -> T
 where
     F: Future<Output = T>,
 {
-    if let Some(_lock) = RUNTIME.get() {
-        let _guard = _lock.read().unwrap();
-
-        if let Some(rt) = &*_guard {
-            return rt.0.block_on(task);
-        }
-    }
-
     let temp_rt = runtime::Builder::new_current_thread()
         .enable_all()
         .build()


### PR DESCRIPTION
We missed a place where we invoke `container` while the async runtime is kept alive, in `postblit`.

Having a global runtime without a clear guarantee around lifetime makes it very easy to miss this. We can fix this in two ways, both eliminate the use of a global static runtime:

- Pass the runtime around the codebase giving us precise control of when to drop / re-init a new one
- Make `block_on` always construct a single use runtime that is dropped before returning the completed task

I've chosen the latter for simplicity, even if its less efficient. Its impossible to misuse. The first approach still runs risk of someone calling into `container` from some nested function that isn't aware an active `runtime` is held across its call site. This means that unless we pass ownership of runtime into and out of every function, we can easily lose track and hit this bug again.