### PR TITLE
moss: Add tracing to remove command

### DIFF
--- a/moss/src/cli/remove.rs
+++ b/moss/src/cli/remove.rs
@@ -16,7 +16,7 @@ use moss::{
     registry::transaction,
     state::Selection,
 };
-use tracing::{debug, info, info_span, instrument, warn};
+use tracing::{debug, info, instrument, warn};
 use tui::{
     Styled,
     dialoguer::{Confirm, theme::ColorfulTheme},
@@ -88,7 +88,6 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
         "Package resolution for removal completed"
     );
 
-    debug!(count = removed.len(), "Full package list for removal");
     for package in &removed {
         debug!(
             name = %package.meta.name,
@@ -117,15 +116,6 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
     }
 
     instant = Instant::now();
-
-    let removal_span = info_span!("progress", phase = "removal", event_type = "progress");
-    let _removal_guard = removal_span.enter();
-    info!(
-        phase = "removal",
-        total_items = removed.len(),
-        progress = 0.0,
-        event_type = "progress_start",
-    );
 
     // Print each package to stdout
     for package in &removed {
@@ -169,14 +159,6 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
     client.new_state(&new_state_pkgs, "Remove")?;
 
     timing.blit = instant.elapsed();
-    info!(
-        phase = "removal",
-        duration_ms = timing.blit.as_millis(),
-        items_processed = removed.len(),
-        progress = 1.0,
-        event_type = "progress_completed",
-    );
-    drop(_removal_guard);
 
     info!(
         blit_time_ms = timing.blit.as_millis(),

--- a/moss/src/cli/sync.rs
+++ b/moss/src/cli/sync.rs
@@ -146,7 +146,6 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
     let cache_packages_span = info_span!("progress", phase = "cache_packages", event_type = "progress");
     let _cache_packages_guard = cache_packages_span.enter();
     info!(
-        phase = "cache_packages",
         total_items = synced.len(),
         progress = 0.0,
         event_type = "progress_start"
@@ -156,7 +155,6 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
 
     timing.fetch = instant.elapsed();
     info!(
-        phase = "cache_packages",
         duration_ms = timing.fetch.as_millis(),
         items_processed = synced.len(),
         progress = 1.0,
@@ -201,27 +199,10 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
             .collect::<Vec<_>>()
     };
 
-    let sync_span = info_span!("progress", phase = "sync", event_type = "progress");
-    let _sync_guard = sync_span.enter();
-    info!(
-        phase = "sync",
-        total_items = new_selections.len(),
-        progress = 0.0,
-        event_type = "progress_start",
-    );
-
     // Perfect, apply state.
     client.new_state(&new_selections, "Sync")?;
 
     timing.blit = instant.elapsed();
-    info!(
-        phase = "sync",
-        duration_ms = timing.blit.as_millis(),
-        items_processed = new_selections.len(),
-        progress = 1.0,
-        event_type = "progress_completed",
-    );
-    drop(_sync_guard);
 
     info!(
         blit_time_ms = timing.blit.as_millis(),

--- a/moss/src/client/install.rs
+++ b/moss/src/client/install.rs
@@ -108,7 +108,6 @@ pub fn install(client: &mut Client, pkgs: &[&str], yes: bool) -> Result<Timing, 
     let cache_packages_span = info_span!("progress", phase = "cache_packages", event_type = "progress");
     let _cache_packages_guard = cache_packages_span.enter();
     info!(
-        phase = "cache_packages",
         total_items = missing.len(),
         progress = 0.0,
         event_type = "progress_start"
@@ -119,7 +118,6 @@ pub fn install(client: &mut Client, pkgs: &[&str], yes: bool) -> Result<Timing, 
 
     timing.fetch = instant.elapsed();
     info!(
-        phase = "cache_packages",
         duration_ms = timing.fetch.as_millis(),
         items_processed = missing.len(),
         progress = 1.0,
@@ -146,27 +144,10 @@ pub fn install(client: &mut Client, pkgs: &[&str], yes: bool) -> Result<Timing, 
         missing_selections.chain(previous_selections).collect::<Vec<_>>()
     };
 
-    let install_span = info_span!("progress", phase = "installation", event_type = "progress");
-    let _install_guard = install_span.enter();
-    info!(
-        phase = "installation",
-        total_items = new_state_pkgs.len(),
-        progress = 0.0,
-        event_type = "progress_start",
-    );
-
     // Perfect, apply state.
     client.new_state(&new_state_pkgs, "Install")?;
 
     timing.blit = instant.elapsed();
-    info!(
-        phase = "installation",
-        duration_ms = timing.blit.as_millis(),
-        items_processed = new_state_pkgs.len(),
-        progress = 1.0,
-        event_type = "progress_completed",
-    );
-    drop(_install_guard);
 
     info!(
         blit_time_ms = timing.blit.as_millis(),


### PR DESCRIPTION
Add tracing to the `moss remove` command per #558.

Also changed progress message from "Installing" to "Blitting" in `blit_element()` for consistency across install/remove/sync operations.