### PR TITLE
boulder: Mount ccache config if exists

### DIFF
--- a/boulder/src/container.rs
+++ b/boulder/src/container.rs
@@ -27,6 +27,7 @@ where
     let cargocache = paths.cargocache();
     let rustc_wrapper = paths.sccache();
     let recipe = paths.recipe();
+    let ccache_conf = paths.ccache_config();
 
     Container::new(rootfs)
         .hostname("boulder")
@@ -41,6 +42,7 @@ where
         .bind_rw(&cargocache.host, &cargocache.guest)
         .bind_rw(&rustc_wrapper.host, &rustc_wrapper.guest)
         .bind_ro(&recipe.host, &recipe.guest)
+        .bind_ro_if_exists(&ccache_conf.host, &ccache_conf.guest)
         .run::<E>(f)?;
 
     Ok(())

--- a/boulder/src/paths.rs
+++ b/boulder/src/paths.rs
@@ -91,6 +91,14 @@ impl Paths {
         }
     }
 
+    // Allows the person building to adjust ccache configuration, most usefully the size of the cache
+    pub fn ccache_config(&self) -> Mapping {
+        Mapping {
+            host: "/etc/ccache".into(),
+            guest: "/etc/ccache".into(),
+        }
+    }
+
     pub fn gocache(&self) -> Mapping {
         Mapping {
             host: self.host_root.join("gocache"),

--- a/crates/container/src/lib.rs
+++ b/crates/container/src/lib.rs
@@ -81,6 +81,21 @@ impl Container {
         self
     }
 
+    /// Create a read-only bind mount only if the `host` path exists
+    pub fn bind_ro_if_exists(mut self, host: impl Into<PathBuf>, guest: impl Into<PathBuf>) -> Self {
+        let source = host.into();
+
+        if source.exists() {
+            self.binds.push(Bind {
+                source,
+                target: guest.into(),
+                read_only: true,
+            });
+        }
+
+        self
+    }
+
     /// Configure networking availability
     pub fn networking(self, enabled: bool) -> Self {
         Self {


### PR DESCRIPTION
If `/etc/ccache` exists on the host system, mount it into the container. This allows for overriding the ccache config.