### PR TITLE
Cargo.toml: Update to resolver = "3"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 members = ["boulder", "moss", "crates/*"]
 default-members = ["moss"]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 version = "0.25.6"


### PR DESCRIPTION
We use the 2024 edition of Rust, which already defaults to resolver = "3"

However, because we use a root-level cargo workspace, we need to specify this manually.

Note that we are setting a MSRV of 1.85 and resolver = "3" has been supported since 1.84.

Tested by doing a `cargo test` run with resolver = "3".