### PR TITLE
macros: Document the %(cargo_target_dir) definition

### DIFF
--- a/boulder/data/macros/actions/cargo.yaml
+++ b/boulder/data/macros/actions/cargo.yaml
@@ -8,6 +8,9 @@ actions:
             CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO="off"; export CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO;
             CARGO_PROFILE_RELEASE_LTO="off"; export CARGO_PROFILE_RELEASE_LTO;
             CARGO_PROFILE_RELEASE_STRIP="none"; export CARGO_PROFILE_RELEASE_STRIP;
+        example: |
+            environment: |
+                %cargo_set_environment
 
     - cargo_fetch:
         description: Fetch dependencies
@@ -25,14 +28,14 @@ actions:
             - binary(cargo)
 
     - cargo_build:
-        description: Build the rust project
+        description: Build the rust project to %(cargo_target_dir)
         command: |
             cargo build %(options_cargo_release)
         dependencies:
             - binary(cargo)
 
     - cargo_install:
-        description: Install the built binary
+        description: Install the build artefacts from %(cargo_target_dir)
         command: |
             cargo_install(){
                 if [ $# -gt 0 ]; then


### PR DESCRIPTION
Our cargo action macros builds artefacts to, and installs artefacts from, the %(cargo_target_dir) definition.
```
󰌽 ermo@virgil:~/repos/aos/os-tools [  ermo/document-cargo_target_dir-definition ? ]  v1.91.0
❯ boulder recipe macros cargo_build
%cargo_build - Build the rust project to %(cargo_target_dir)
󰌽 ermo@virgil:~/repos/aos/os-tools [  ermo/document-cargo_target_dir-definition ? ]  v1.91.0
❯ boulder recipe macros cargo_install
%cargo_install - Install the build artefacts from %(cargo_target_dir)
```