### PR TITLE
boulder: Add caching for golang builds

### DIFF
--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -53,6 +53,7 @@ definitions:
     - path           : "%(compiler_path)"
     - ccachedir      : "%(compiler_cache)"
     - gocachedir     : "%(compiler_go_cache)"
+    - gomodcachedir  : "%(compiler_go_mod_cache)"
     - sccachedir     : "%(scompiler_cache)"
     - pkgconfigpath  : "%(libdir)/pkgconfig:/usr/share/pkgconfig"
 
@@ -100,6 +101,8 @@ actions              :
             test -z "$RUSTC_WRAPPER" && unset RUSTC_WRAPPER;
             GOCACHE="%(gocachedir)"; export GOCACHE;
             test -z "$GOCACHE" && unset GOCACHE;
+            GOMODCACHE="%(gomodcachedir)"; export GOMODCACHE;
+            test -z "$GOMODCACHE" && unset GOMODCACHE;
             SCCACHE_DIR="%(sccachedir)"; export SCCACHE_DIR;
             test -z "$SCCACHE_DIR" && unset SCCACHE_DIR;
             LANG="en_US.UTF-8"; export LANG

--- a/boulder/src/build/job/phase.rs
+++ b/boulder/src/build/job/phase.rs
@@ -162,9 +162,11 @@ impl Phase {
 
         if ccache {
             parser.add_definition("compiler_go_cache", "/mason/gocache");
+            parser.add_definition("compiler_go_mod_cache", "/mason/gomodcache");
             parser.add_definition("rustc_wrapper", "/usr/bin/sccache");
         } else {
             parser.add_definition("compiler_go_cache", "");
+            parser.add_definition("compiler_go_mod_cache", "");
             parser.add_definition("rustc_wrapper", "");
         }
 

--- a/boulder/src/container.rs
+++ b/boulder/src/container.rs
@@ -23,6 +23,7 @@ where
     let build = paths.build();
     let compiler = paths.ccache();
     let gocache = paths.gocache();
+    let gomodcache = paths.gomodcache();
     let rustc_wrapper = paths.sccache();
     let recipe = paths.recipe();
 
@@ -35,6 +36,7 @@ where
         .bind_rw(&build.host, &build.guest)
         .bind_rw(&compiler.host, &compiler.guest)
         .bind_rw(&gocache.host, &gocache.guest)
+        .bind_rw(&gomodcache.host, &gomodcache.guest)
         .bind_rw(&rustc_wrapper.host, &rustc_wrapper.guest)
         .bind_ro(&recipe.host, &recipe.guest)
         .run::<E>(f)?;

--- a/boulder/src/paths.rs
+++ b/boulder/src/paths.rs
@@ -54,6 +54,7 @@ impl Paths {
         util::ensure_dir_exists(&job.build().host)?;
         util::ensure_dir_exists(&job.ccache().host)?;
         util::ensure_dir_exists(&job.gocache().host)?;
+        util::ensure_dir_exists(&job.gomodcache().host)?;
         util::ensure_dir_exists(&job.sccache().host)?;
         util::ensure_dir_exists(&job.upstreams().host)?;
 
@@ -92,6 +93,13 @@ impl Paths {
         Mapping {
             host: self.host_root.join("gocache"),
             guest: self.guest_root.join("gocache"),
+        }
+    }
+
+    pub fn gomodcache(&self) -> Mapping {
+        Mapping {
+            host: self.host_root.join("gomodcache"),
+            guest: self.guest_root.join("gomodcache"),
         }
     }
 


### PR DESCRIPTION
Pretty simple, add a host mount for /mason/gocache and then set the GOCACHE envvar to tell golang to use it.

Enabled only if running boulder with `--compiler-cache`

This was tested with building dagger, and reduced the build phase time from 141.32s to 10.55s, or a 92% reduction.