### PR TITLE
boulder: Add global cargo cache

### DIFF
--- a/boulder/data/macros/actions/cargo.yaml
+++ b/boulder/data/macros/actions/cargo.yaml
@@ -57,6 +57,15 @@ actions:
         dependencies:
             - binary(cargo)
 
+    # Some builds might break if CARGO_HOME is set (used for the global cargo cache). Add a descriptive macro for when this is the case
+    - cargo_home_breaks_this_build:
+        description: Use this macro to indicate that setting CARGO_HOME breaks this build
+        example: |
+            environment: |
+                %cargo_home_breaks_this_build
+        command: |
+            unset CARGO_HOME
+
 definitions:
     # The default cargo build profile
     - cargo_profile: "release"

--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -54,6 +54,7 @@ definitions:
     - ccachedir      : "%(compiler_cache)"
     - gocachedir     : "%(compiler_go_cache)"
     - gomodcachedir  : "%(compiler_go_mod_cache)"
+    - cargocachedir  : "%(compiler_cargo_cache)"
     - sccachedir     : "%(scompiler_cache)"
     - pkgconfigpath  : "%(libdir)/pkgconfig:/usr/share/pkgconfig"
 
@@ -103,6 +104,8 @@ actions              :
             test -z "$GOCACHE" && unset GOCACHE;
             GOMODCACHE="%(gomodcachedir)"; export GOMODCACHE;
             test -z "$GOMODCACHE" && unset GOMODCACHE;
+            CARGO_HOME="%(cargocachedir)"; export CARGO_HOME;
+            test -z "$CARGO_HOME" && unset CARGO_HOME;
             SCCACHE_DIR="%(sccachedir)"; export SCCACHE_DIR;
             test -z "$SCCACHE_DIR" && unset SCCACHE_DIR;
             LANG="en_US.UTF-8"; export LANG

--- a/boulder/src/build/job/phase.rs
+++ b/boulder/src/build/job/phase.rs
@@ -163,10 +163,12 @@ impl Phase {
         if ccache {
             parser.add_definition("compiler_go_cache", "/mason/gocache");
             parser.add_definition("compiler_go_mod_cache", "/mason/gomodcache");
+            parser.add_definition("compiler_cargo_cache", "/mason/cargocache");
             parser.add_definition("rustc_wrapper", "/usr/bin/sccache");
         } else {
             parser.add_definition("compiler_go_cache", "");
             parser.add_definition("compiler_go_mod_cache", "");
+            parser.add_definition("compiler_cargo_cache", "");
             parser.add_definition("rustc_wrapper", "");
         }
 

--- a/boulder/src/container.rs
+++ b/boulder/src/container.rs
@@ -24,6 +24,7 @@ where
     let compiler = paths.ccache();
     let gocache = paths.gocache();
     let gomodcache = paths.gomodcache();
+    let cargocache = paths.cargocache();
     let rustc_wrapper = paths.sccache();
     let recipe = paths.recipe();
 
@@ -37,6 +38,7 @@ where
         .bind_rw(&compiler.host, &compiler.guest)
         .bind_rw(&gocache.host, &gocache.guest)
         .bind_rw(&gomodcache.host, &gomodcache.guest)
+        .bind_rw(&cargocache.host, &cargocache.guest)
         .bind_rw(&rustc_wrapper.host, &rustc_wrapper.guest)
         .bind_ro(&recipe.host, &recipe.guest)
         .run::<E>(f)?;

--- a/boulder/src/paths.rs
+++ b/boulder/src/paths.rs
@@ -55,6 +55,7 @@ impl Paths {
         util::ensure_dir_exists(&job.ccache().host)?;
         util::ensure_dir_exists(&job.gocache().host)?;
         util::ensure_dir_exists(&job.gomodcache().host)?;
+        util::ensure_dir_exists(&job.cargocache().host)?;
         util::ensure_dir_exists(&job.sccache().host)?;
         util::ensure_dir_exists(&job.upstreams().host)?;
 
@@ -100,6 +101,13 @@ impl Paths {
         Mapping {
             host: self.host_root.join("gomodcache"),
             guest: self.guest_root.join("gomodcache"),
+        }
+    }
+
+    pub fn cargocache(&self) -> Mapping {
+        Mapping {
+            host: self.host_root.join("cargocache"),
+            guest: self.guest_root.join("cargocache"),
         }
     }
 


### PR DESCRIPTION
The cargo global cache, used for caching downloaded crates and dependencies, goes in $CARGO_HOME, so set that value and add a persistent mapping for it.

This was tested to bring the fetch phase for amdgpu_top down from 5.09s to 0.63s.

While that gain is marginal for single-package builds the real value is when doing a large rust stack like COSMIC where many dependencies are shared (though the impact is still likely minimal).

Also, while I didn't test any other packages in the repo I can forsee that some packages have unique CARGO_HOME handling and may break some builds. To indicate where that happens add a descriptive macro that unsets the variable.