### PR TITLE
moss: Fix bug from 03c348a1, hook up cache dir

### DIFF
--- a/moss/src/installation.rs
+++ b/moss/src/installation.rs
@@ -101,7 +101,7 @@ impl Installation {
             root,
             mutability,
             active_state,
-            cache_dir: None,
+            cache_dir,
             _locks,
         })
     }


### PR DESCRIPTION
03c348a1 introduced a regression where `cache_dir` was moved from a builder function to `open` but it never got used.