### PR TITLE
container: Bind mount via open_tree -> move_mount

### DIFF
--- a/boulder/src/cli.rs
+++ b/boulder/src/cli.rs
@@ -163,7 +163,7 @@ fn replace_aliases(args: std::env::Args) -> Vec<String> {
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("build")]
-    Build(Box<build::Error>),
+    Build(#[source] Box<build::Error>),
     #[error("chroot")]
     Chroot(#[from] chroot::Error),
     #[error("profile")]


### PR DESCRIPTION
Traditional mount(2) w/ remount,ro fails w/ EPERM on certain setups, like an ext4 mounted fs via a
luks mapped device. However, running `mount` via CLI works and an `strace` points to the use of
`open_tree` -> `mount_setattr` -> `move_mount`.

This creates a "detached" bind mount via a file descriptor. We then set the `ro` attribute on this 
detached mount before finally moving it to its target destination. This combination appears to fix things on the above setup while still being a valid equivalent  "newer" way to do a bind mount.

These "newer" syscalls are available since linux 5.2 so this should be new enough for our concerns.

`move_mount(2)` docs show the following example to  do a `mount(2)` functionallty equivalent mount, which is what we follow:

> The same operation also works with detached bind-mounts
> created with open_tree(2) with OPEN_TREE_CLONE:
>
> ```c
> int mntfd = open_tree(AT_FDCWD, "/home/cyphar", OPEN_TREE_CLONE);
> move_mount(mntfd, "", AT_FDCWD, "/root", MOVE_MOUNT_F_EMPTY_PATH);
> ```
> 
> This would create a new bind-mount of /home/cyphar
> as a detached mount object, and then attach it to /root.
> The above procedure is functionally equivalent to the
> following mount operation using mount(2):
> 
> ```c
> mount("/home/cyphar", "/root", NULL, MS_BIND, NULL);
> ```