### PR TITLE
container: use nc over libc for move_mount for musl support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,9 +351,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.37"
+version = "1.2.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
+checksum = "9f50d563227a1c37cc0a263f64eca3334388c01c5e4c4861a9def205c614383c"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -564,6 +564,7 @@ name = "container"
 version = "0.25.6"
 dependencies = [
  "fs-err",
+ "nc",
  "nix 0.27.1",
  "snafu",
  "strum",
@@ -1037,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.1"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "fixedbitset"
@@ -1894,6 +1895,15 @@ dependencies = [
  "vfs",
  "xxhash-rust",
  "zbus",
+]
+
+[[package]]
+name = "nc"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44a4f56a68f96b49bca0ea29a91caa983bb5f37e064183436a45b80dc441cd55"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ hex = "0.4.3"
 indextree = "4.6.1"
 libsqlite3-sys = { version = "0.35.0", features = ["bundled"] }
 log = "0.4.22"
+nc = "0.9.7"
 nom = "7.1.3"
 nix = { version = "0.27.1", features = [
     "user",

--- a/crates/container/Cargo.toml
+++ b/crates/container/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 fs-err.workspace = true
+nc.workspace = true
 nix.workspace = true
 snafu.workspace = true
 strum.workspace = true


### PR DESCRIPTION
`nix -> libc` doesn't expose `move_mount` and related things for `musl`. `nc` gives us syscall bindings w/out reliance on `libc`.

The context for this is that we need to be able to build stand-alone, statically compiled boulder binaries against musl for the purpose of convenience of distribution.