### PR TITLE
boulder: Check for int in version string first char

### DIFF
--- a/boulder/src/recipe.rs
+++ b/boulder/src/recipe.rs
@@ -33,12 +33,23 @@ impl Recipe {
         let build_time = resolve_build_time(&path);
 
         // Invariant checks
+
+        // We want versions to start with an integer for ent comparison purposes
+        if !parsed.source.version.starts_with(|c: char| c.is_ascii_digit()) {
+            return Err(Error::Value(format!(
+                "version must start with an integer (found 'version: {}')",
+                parsed.source.version
+            )));
+        }
+
+        // Setting release to 0 is a common mistake
         if parsed.source.release == 0 {
             return Err(Error::Value(format!(
                 "release must be > 0 (found 'release: {}')",
                 parsed.source.release
             )));
         }
+
         // Invariant checks done
 
         Ok(Self {


### PR DESCRIPTION
Regrettably, I sometimes forget to check that version strings start with an integer when reviewing recipe PRs, which means that strings like 'v1.2.3' sometimes slip through.

This makes it impossible to match version strings with ent, so fix this by adding a check that makes boulder error out unless the first char in the version string is an integer.

**Test Cases**:

```
~/repos/aos/recipes/y/yazi
❯ grep version stone.yaml
version     : v25.5.31
:~/repos/aos/recipes/y/yazi
❯ boulder build

Error: build: build recipe: recipe: value: version must start with an integer (found 'version: v25.5.31')
~/repos/aos/recipes/y/yazi

(... edit and fix the version string ...)

❯ grep version stone.yaml
version     : 25.5.31
~/repos/aos/recipes/y/yazi
❯ boulder build
boulder v0.25.6 (Git ref 2d662d38268214230873cc687b318e0852ca077e-dirty)
└─ building yazi-25.5.31-2-1

(...)
```