### PR TITLE
stone: Decode unknown variants

### DIFF
--- a/crates/stone/src/header/v1.rs
+++ b/crates/stone/src/header/v1.rs
@@ -11,8 +11,8 @@ const INTEGRITY_CHECK: [u8; 21] = [0, 0, 1, 0, 0, 2, 0, 0, 3, 0, 0, 4, 0, 0, 5, 
 ///
 /// Some types are now legacy as we're going to use Ion to define them.
 ///
-#[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
 pub enum FileType {
     /// Binary package
     Binary = 1,
@@ -25,6 +25,8 @@ pub enum FileType {
 
     /// (Legacy) build manifest
     BuildManifest,
+
+    Unknown = 255,
 }
 
 /// Header for the v1 format version
@@ -49,7 +51,7 @@ impl Header {
             2 => FileType::Delta,
             3 => FileType::Repository,
             4 => FileType::BuildManifest,
-            f => return Err(DecodeError::UnknownFileType(f)),
+            _ => FileType::Unknown,
         };
 
         Ok(Self {
@@ -76,6 +78,4 @@ impl Header {
 pub enum DecodeError {
     #[error("Corrupt header, failed integrity check")]
     Corrupt,
-    #[error("Unknown file type: {0}")]
-    UnknownFileType(u8),
 }

--- a/crates/stone/src/payload/layout.rs
+++ b/crates/stone/src/payload/layout.rs
@@ -11,8 +11,8 @@ use crate::{ReadExt, WriteExt};
 
 /// Layout entries record their target file type so they can be rebuilt on
 /// the target installation.
-#[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
 pub enum FileType {
     /// Regular file
     Regular = 1,
@@ -34,6 +34,8 @@ pub enum FileType {
 
     /// UNIX Socket
     Socket,
+
+    Unknown = 255,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -47,6 +49,8 @@ pub enum Entry {
     BlockDevice(AStr),
     Fifo(AStr),
     Socket(AStr),
+
+    Unknown(AStr, AStr),
 }
 
 impl Entry {
@@ -59,18 +63,20 @@ impl Entry {
             Entry::BlockDevice(_) => vec![],
             Entry::Fifo(_) => vec![],
             Entry::Socket(_) => vec![],
+            Entry::Unknown(source, _) => source.as_bytes().to_vec(),
         }
     }
 
     pub fn target(&self) -> &str {
         match self {
-            Entry::Regular(_, target) => target,
-            Entry::Symlink(_, target) => target,
-            Entry::Directory(target) => target,
-            Entry::CharacterDevice(target) => target,
-            Entry::BlockDevice(target) => target,
-            Entry::Fifo(target) => target,
-            Entry::Socket(target) => target,
+            Entry::Regular(_, target)
+            | Entry::Symlink(_, target)
+            | Entry::Directory(target)
+            | Entry::CharacterDevice(target)
+            | Entry::BlockDevice(target)
+            | Entry::Fifo(target)
+            | Entry::Socket(target)
+            | Entry::Unknown(_, target) => target,
         }
     }
 
@@ -83,6 +89,7 @@ impl Entry {
             Entry::BlockDevice(_) => 5,
             Entry::Fifo(_) => 6,
             Entry::Socket(_) => 7,
+            Entry::Unknown(..) => 255,
         }
     }
 }
@@ -118,14 +125,13 @@ impl Record for Layout {
             5 => FileType::BlockDevice,
             6 => FileType::Fifo,
             7 => FileType::Socket,
-            t => return Err(DecodeError::UnknownFileType(t)),
+            _ => FileType::Unknown,
         };
 
         let _padding = reader.read_array::<11>()?;
 
         // Make the layout entry *usable*
         let entry = match file_type {
-            // BUG: boulder stores xxh128 as le bytes not be
             FileType::Regular => {
                 let source = reader.read_vec(source_length as usize)?;
                 let hash = u128::from_be_bytes(source.try_into().unwrap());
@@ -136,12 +142,16 @@ impl Record for Layout {
                 sanitize(&reader.read_string(target_length as u64)?).into(),
             ),
             FileType::Directory => Entry::Directory(sanitize(&reader.read_string(target_length as u64)?).into()),
-            _ => {
-                if source_length > 0 {
-                    let _ = reader.read_vec(source_length as usize);
-                }
-                unreachable!()
+            FileType::CharacterDevice => {
+                Entry::CharacterDevice(sanitize(&reader.read_string(target_length as u64)?).into())
             }
+            FileType::BlockDevice => Entry::BlockDevice(sanitize(&reader.read_string(target_length as u64)?).into()),
+            FileType::Fifo => Entry::Fifo(sanitize(&reader.read_string(target_length as u64)?).into()),
+            FileType::Socket => Entry::Socket(sanitize(&reader.read_string(target_length as u64)?).into()),
+            FileType::Unknown => Entry::Unknown(
+                sanitize(&reader.read_string(source_length as u64)?).into(),
+                sanitize(&reader.read_string(target_length as u64)?).into(),
+            ),
         };
 
         Ok(Self {

--- a/moss/src/client/mod.rs
+++ b/moss/src/client/mod.rs
@@ -947,11 +947,12 @@ impl Client {
                 stats.num_dirs += 1;
             }
 
-            // unimplemented
-            layout::Entry::CharacterDevice(_) => todo!(),
-            layout::Entry::BlockDevice(_) => todo!(),
-            layout::Entry::Fifo(_) => todo!(),
-            layout::Entry::Socket(_) => todo!(),
+            // Unimplemented
+            layout::Entry::CharacterDevice(_)
+            | layout::Entry::BlockDevice(_)
+            | layout::Entry::Fifo(_)
+            | layout::Entry::Socket(_)
+            | layout::Entry::Unknown(..) => {}
         };
 
         Ok(())
@@ -1154,6 +1155,7 @@ impl BlitFile for PendingFile {
             layout::Entry::BlockDevice(target) => target.clone(),
             layout::Entry::Fifo(target) => target.clone(),
             layout::Entry::Socket(target) => target.clone(),
+            layout::Entry::Unknown(.., target) => target.clone(),
         };
 
         vfs::path::join("/usr", &result)
@@ -1170,6 +1172,7 @@ impl BlitFile for PendingFile {
             layout::Entry::BlockDevice(_) => layout::Entry::BlockDevice(path),
             layout::Entry::Fifo(_) => layout::Entry::Fifo(path),
             layout::Entry::Socket(_) => layout::Entry::Socket(path),
+            layout::Entry::Unknown(source, _) => layout::Entry::Unknown(source.clone(), path),
         };
         new
     }

--- a/moss/src/db/layout/mod.rs
+++ b/moss/src/db/layout/mod.rs
@@ -197,6 +197,7 @@ fn decode_entry(
         "block-device" => Some(Entry::BlockDevice(entry_value1?)),
         "fifo" => Some(Entry::Fifo(entry_value1?)),
         "socket" => Some(Entry::Socket(entry_value1?)),
+        "unknown" => Some(Entry::Unknown(entry_value1?, entry_value2?)),
         _ => None,
     }
 }
@@ -212,6 +213,7 @@ fn encode_entry(entry: &payload::layout::Entry) -> (&'static str, Option<Cow<'_,
         Entry::BlockDevice(name) => ("block-device", Some(name.into()), None),
         Entry::Fifo(name) => ("fifo", Some(name.into()), None),
         Entry::Socket(name) => ("socket", Some(name.into()), None),
+        Entry::Unknown(a, b) => ("unknown", Some(a.into()), Some(b)),
     }
 }
 

--- a/moss/src/dependency.rs
+++ b/moss/src/dependency.rs
@@ -61,10 +61,10 @@ pub enum Kind {
     PkgConfig32,
 }
 
-/// Convert payload dependency types to our internal representation
-impl From<payload::meta::Dependency> for Kind {
-    fn from(dependency: payload::meta::Dependency) -> Self {
-        match dependency {
+impl Kind {
+    pub fn from_stone_dependency(dependency: payload::meta::Dependency) -> Option<Self> {
+        Some(match dependency {
+            payload::meta::Dependency::Unknown => return None,
             payload::meta::Dependency::PackageName => Kind::PackageName,
             payload::meta::Dependency::SharedLibrary => Kind::SharedLibrary,
             payload::meta::Dependency::PkgConfig => Kind::PkgConfig,
@@ -74,7 +74,7 @@ impl From<payload::meta::Dependency> for Kind {
             payload::meta::Dependency::Binary => Kind::Binary,
             payload::meta::Dependency::SystemBinary => Kind::SystemBinary,
             payload::meta::Dependency::PkgConfig32 => Kind::PkgConfig32,
-        }
+        })
     }
 }
 

--- a/moss/src/package/meta.rs
+++ b/moss/src/package/meta.rs
@@ -213,7 +213,7 @@ fn meta_string(meta: &payload::Meta, tag: payload::meta::Tag) -> Option<String> 
 fn meta_dependency(meta: &payload::Meta) -> Option<Dependency> {
     if let payload::meta::Kind::Dependency(kind, name) = meta.kind.clone() {
         Some(Dependency {
-            kind: dependency::Kind::from(kind),
+            kind: dependency::Kind::from_stone_dependency(kind)?,
             name,
         })
     } else {
@@ -224,7 +224,7 @@ fn meta_dependency(meta: &payload::Meta) -> Option<Dependency> {
 fn meta_provider(meta: &payload::Meta) -> Option<Provider> {
     match (meta.tag, meta.kind.clone()) {
         (payload::meta::Tag::Provides, payload::meta::Kind::Provider(kind, name)) => Some(Provider {
-            kind: dependency::Kind::from(kind),
+            kind: dependency::Kind::from_stone_dependency(kind)?,
             name: name.clone(),
         }),
         _ => None,
@@ -234,7 +234,7 @@ fn meta_provider(meta: &payload::Meta) -> Option<Provider> {
 fn meta_conflict(meta: &payload::Meta) -> Option<Provider> {
     match (meta.tag, meta.kind.clone()) {
         (payload::meta::Tag::Conflicts, payload::meta::Kind::Provider(kind, name)) => Some(Provider {
-            kind: dependency::Kind::from(kind),
+            kind: dependency::Kind::from_stone_dependency(kind)?,
             name: name.clone(),
         }),
         _ => None,


### PR DESCRIPTION
Our current decode implementation breaks on unknown variants in our payload data. This makes it impossible to add backwards compatible changes (new meta types) without breaking older moss installs.

This change allows moss to decode unknown variants and effectively ignore them so we can be forwards compatible with future changes that don't require a hard format bump to support (conflicts, replaces, retires, tags, etc) & without having to split those stones into a newer format repository since they can still be understood & used by older installs (just missing non-mandatory functionality). 