### PR TITLE
moss: Split cache::Error in two and use snafu for them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1920,6 +1920,7 @@ dependencies = [
  "reqwest",
  "serde",
  "sha2",
+ "snafu",
  "stone",
  "strum",
  "thiserror",

--- a/moss/Cargo.toml
+++ b/moss/Cargo.toml
@@ -39,6 +39,7 @@ rayon.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 sha2.workspace = true
+snafu.workspace = true
 strum.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true

--- a/moss/src/client/mod.rs
+++ b/moss/src/client/mod.rs
@@ -1356,9 +1356,9 @@ pub enum Error {
     #[error("installation")]
     Installation(#[from] installation::Error),
     #[error("fetch package {1}")]
-    CacheFetch(#[source] cache::Error, package::Name),
+    CacheFetch(#[source] cache::FetchError, package::Name),
     #[error("unpack package {1}, file {2}")]
-    CacheUnpack(#[source] cache::Error, package::Name, PathBuf),
+    CacheUnpack(#[source] cache::UnpackError, package::Name, PathBuf),
     #[error("repository manager")]
     Repository(#[from] repository::manager::Error),
     #[error("db")]


### PR DESCRIPTION
Follow-up to #668.