### PR TITLE
Fix formatting of options_cmake_make

### DIFF
--- a/boulder/data/macros/actions/cmake.yaml
+++ b/boulder/data/macros/actions/cmake.yaml
@@ -72,5 +72,5 @@ definitions:
 
     # Use cmake with make as the build server
     - options_cmake_make: |
-        -G Unix Makefiles \
+        -G "Unix Makefiles" \
         %(options_cmake)


### PR DESCRIPTION
`CMake Error: Could not create named generator Unix`