### PR TITLE
boulder: Detect archive package based on upstream rename

### DIFF
--- a/boulder/src/build/root.rs
+++ b/boulder/src/build/root.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use std::collections::BTreeSet;
-use std::io;
+use std::{io, iter};
 
 use fs_err as fs;
 use moss::{Installation, repository, runtime, util};
@@ -150,42 +150,44 @@ fn packages(builder: &Builder) -> Vec<&str> {
     );
 
     for upstream in &builder.recipe.parsed.upstreams {
-        if let Upstream::Plain { uri, .. } = upstream {
+        if let Upstream::Plain { uri, rename, .. } = upstream {
             let path = uri.path();
 
-            if let Some((_, ext)) = path.rsplit_once('.') {
-                match ext {
-                    "xz" => {
-                        packages.push("binary(bsdtar-static)");
+            for path in iter::once(path).chain(rename.as_deref()) {
+                if let Some((_, ext)) = path.rsplit_once('.') {
+                    match ext {
+                        "xz" => {
+                            packages.push("binary(bsdtar-static)");
+                        }
+                        "zst" => {
+                            packages.push("binary(bsdtar-static)");
+                        }
+                        "bz2" => {
+                            packages.push("binary(bsdtar-static)");
+                        }
+                        "gz" => {
+                            packages.push("binary(bsdtar-static)");
+                        }
+                        "lz" => {
+                            packages.push("binary(bsdtar-static)");
+                        }
+                        "tgz" => {
+                            packages.push("binary(bsdtar-static)");
+                        }
+                        "7z" => {
+                            packages.push("binary(bsdtar-static)");
+                        }
+                        "zip" => {
+                            packages.push("binary(bsdtar-static)");
+                        }
+                        "rpm" => {
+                            packages.extend(["binary(rpm2cpio)", "cpio"]);
+                        }
+                        "deb" => {
+                            packages.push("binary(ar)");
+                        }
+                        _ => {}
                     }
-                    "zst" => {
-                        packages.push("binary(bsdtar-static)");
-                    }
-                    "bz2" => {
-                        packages.push("binary(bsdtar-static)");
-                    }
-                    "gz" => {
-                        packages.push("binary(bsdtar-static)");
-                    }
-                    "lz" => {
-                        packages.push("binary(bsdtar-static)");
-                    }
-                    "tgz" => {
-                        packages.push("binary(bsdtar-static)");
-                    }
-                    "7z" => {
-                        packages.push("binary(bsdtar-static)");
-                    }
-                    "zip" => {
-                        packages.push("binary(bsdtar-static)");
-                    }
-                    "rpm" => {
-                        packages.extend(["binary(rpm2cpio)", "cpio"]);
-                    }
-                    "deb" => {
-                        packages.push("binary(ar)");
-                    }
-                    _ => {}
                 }
             }
         }


### PR DESCRIPTION
With the following diff, `boulder` should know to add `bsdtar-static` as a package based on the `rename` argument:

```diff
diff --git a/l/lame/stone.yaml b/l/lame/stone.yaml
index 90ce1ab53e..773c1f68ff 100644
--- a/l/lame/stone.yaml
+++ b/l/lame/stone.yaml
@@ -8,13 +8,16 @@
 release     : 5
 homepage    : https://lame.sourceforge.io/
 upstreams   :
-    - https://netcologne.dl.sourceforge.net/project/lame/lame/3.100/lame-3.100.tar.gz : ddfe36cab873794038ae2c1210557ad34857a4b6bdc515785d1da9e175b1da1e
+    - https://sourceforge.net/projects/lame/files/lame/3.100/lame-3.100.tar.gz/download :
+        hash: ddfe36cab873794038ae2c1210557ad34857a4b6bdc515785d1da9e175b1da1e
+        rename: lame.tar.gz
 summary     : LAME is a high quality MPEG Audio Layer III (MP3) encoder
 description : |
     LAME is a high quality MPEG Audio Layer III (MP3) encoder licensed under the LGPL.
 license     :
     - LGPL-2.0-or-later
 builddeps   :
+    - binary(bsdtar-static)
     - binary(nasm)
     - pkgconfig(ncursesw)
 setup       : |
```