### PR TITLE
.github: Check REUSE compliance in parallel to code conformity

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 allow-mixed-uninlined-format-args = false
 disallowed-methods = [
     { path = "std::fs::canonicalize", replacement = "fs_err::canonicalize" },

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2023 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 * @ermo @jplatte @tarkah

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 # https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 name: CI
 
 on:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,46 +12,56 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  meta:
+    runs-on: ubuntu-latest
+    name: Non-code Checks
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+
+      - name: Check for typos
+        uses: crate-ci/typos@v1.43.5
+
+      - name: Check REUSE compliance
+        uses: fsfe/reuse-action@v6.0.0
   build:
     runs-on: ubuntu-latest
     name: Build & Test Project
 
     steps:
-    - name: Checkout source
-      uses: actions/checkout@v4
+      - name: Checkout source
+        uses: actions/checkout@v6
 
-    - name: typos-action
-      uses: crate-ci/typos@v1.29.3
+      - name: Install LLVM and Clang
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 18
+          echo "/usr/lib/llvm-18/bin" >> $GITHUB_PATH
+          echo "CC=/usr/lib/llvm-18/bin/clang" >> $GITHUB_ENV
 
-    - name: Install LLVM and Clang
-      run: |
-        wget https://apt.llvm.org/llvm.sh
-        chmod +x llvm.sh
-        sudo ./llvm.sh 18
-        echo "/usr/lib/llvm-18/bin" >> $GITHUB_PATH
-        echo "CC=/usr/lib/llvm-18/bin/clang" >> $GITHUB_ENV
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
 
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        components: rustfmt, clippy
+      - name: Check Formatting
+        run: cargo fmt --all -- --check
 
-    - name: Check Formatting
-      run: cargo fmt --all -- --check
+      - name: Cargo Cache
+        uses: Swatinem/rust-cache@v2
 
-    - name: Cargo Cache
-      uses: Swatinem/rust-cache@v2
+      - name: Build project
+        run: cargo build
 
-    - name: Build project
-      run: cargo build
+      - name: Test project
+        run: cargo test --all
 
-    - name: Test project
-      run: cargo test --all
-
-    - name: Run clippy
-      uses: giraffate/clippy-action@v1
-      with:
-        reporter: 'github-pr-check'
-        clippy_flags: --workspace --no-deps
-        filter_mode: nofilter
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run clippy
+        uses: giraffate/clippy-action@v1
+        with:
+          reporter: 'github-pr-check'
+          clippy_flags: --workspace --no-deps
+          filter_mode: nofilter
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 name: Release
 
 on:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
+# SPDX-FileCopyrightText: 2023 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 /target
 /.vscode
 target
+typos
 
 **/db/**/test.db
 

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 edition = "2024"
 max_width = 120

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 [default]
 
 [default.extend-words]
@@ -7,6 +10,4 @@ restat = "restat"
 idae = "idae"
 
 [files]
-extend-exclude = [
-    "serpent-style/**/*"
-]
+extend-exclude = ["serpent-style/**/*"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 [workspace]
 members = ["boulder", "moss", "libstone", "crates/*"]
 default-members = ["moss"]
@@ -85,7 +88,11 @@ thread-priority = "3.0.0"
 tokio = { version = "1.38.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io"] }
 tracing = { version = "0.1.41", features = ["attributes"] }
-tracing-subscriber = { version = "0.3.19", default-features = false, features = ["ansi", "fmt", "json"] }
+tracing-subscriber = { version = "0.3.19", default-features = false, features = [
+    "ansi",
+    "fmt",
+    "json",
+] }
 triomphe = { version = "0.1.15", default-features = false }
 url = { version = "2.5.2", features = ["serde"] }
 xxhash-rust = { version = "0.8.11", features = ["xxh3"] }

--- a/DESIGN-NOTES.md
+++ b/DESIGN-NOTES.md
@@ -1,3 +1,8 @@
+---
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+---
+
 # How AerynOS delivers software to OS installs
 
 ## Software package metadata: manifest.*.bin
@@ -10,7 +15,7 @@ The `manifest.${ARCH}.bin` files contain all the metadata needed by the AerynOS 
     > and the stone archive type flag is set to buildmanifest
     > sneaksy
     > (in fact, our repo format is also just a set of meta payloads in a stone file..)
-    > but its also strongly typed, fixed headers, version agnostic header unpack and compressed with zstd with CRC checks 
+    > but its also strongly typed, fixed headers, version agnostic header unpack and compressed with zstd with CRC checks
     > soo. a little less weak than sounding
     > crc is actually xxh64 iirc
 
@@ -22,7 +27,7 @@ AerynOS distributes software via its custom `stone` format. This format was expl
     > Context: we dont mix layout + metadata (unlike in alpine, where tar records are used for metadata)
     > in fact we explicitly separate them
     > so a "normal" stone file has a meta payload with strongly typed/tagged key value pairs/sets
-    > a content payload which is every unique file concatenated into a "megablob" and compressed singly 
+    > a content payload which is every unique file concatenated into a "megablob" and compressed singly
     > an index payload which is a jump table into offsets in the unpacked content payload
     > to allow the xxhash128 keying
     > ie "position one is hash xyz"

--- a/LICENSES/Zlib.txt
+++ b/LICENSES/Zlib.txt
@@ -1,0 +1,11 @@
+zlib License
+
+This software is provided 'as-is', without any express or implied warranty.  In no event will the authors be held liable for any damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose, including commercial applications, and to alter it and redistribute it freely, subject to the following restrictions:
+
+     1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
+
+     2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+
+     3. This notice may not be removed or altered from any source distribution.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+---
+# SPDX-FileCopyrightText: 2023 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+---
+
 # 🛠️ OS Tools - Modern System State Management
 
 ## 📦 Core Tools

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
+version = 1
+
+# Annotate files that we cannot edit or comment.
+# We don't report the initial year for simplicity;
+# it is a valid copyright notice anyway.
+[[annotations]]
+path = [
+    "Cargo.lock",
+    "funding.json",
+    "moss/src/db/*/schema.rs",
+    "test/**/*.stone",
+]
+SPDX-FileCopyrightText = "AerynOS Developers"
+SPDX-License-Identifier = "MPL-2.0"

--- a/boot/module/module-setup.sh
+++ b/boot/module/module-setup.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
 
 installkernel() {
     return 0

--- a/boot/moss-fstx.service
+++ b/boot/moss-fstx.service
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 [Unit]
 Description=Moss state rollback
 DefaultDependencies=no

--- a/boot/moss-fstx.sh
+++ b/boot/moss-fstx.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
 
 type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
 command -v moss > /dev/null || exit 1

--- a/boulder/Cargo.toml
+++ b/boulder/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 [package]
 name = "boulder"
 edition.workspace = true

--- a/boulder/README.md
+++ b/boulder/README.md
@@ -1,3 +1,8 @@
+---
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+---
+
 # Boulder
 
 This directory contains the Serpent OS package building tool `boulder`.

--- a/boulder/boulder-concurrency-test.yaml
+++ b/boulder/boulder-concurrency-test.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 name       : boulder-concurrency-test
 version    : 1
 release    : 1
@@ -22,7 +25,7 @@ build      : |
   #!/usr/bin/env bash
   #
   set -euo pipefail
-  
+
   [[ -f build.log ]] || exit 1
   for a b c d e f g h
   do

--- a/boulder/data/macros/actions/autotools.yaml
+++ b/boulder/data/macros/actions/autotools.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 actions:
 
     # We default to using CONFIG_SHELL==SHELL=/usr/bin/dash because our tests show that it is around

--- a/boulder/data/macros/actions/cargo.yaml
+++ b/boulder/data/macros/actions/cargo.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 actions:
     - cargo_set_environment:
         description: Set environmental variables for Cargo build

--- a/boulder/data/macros/actions/ccache.yaml
+++ b/boulder/data/macros/actions/ccache.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 actions:
     - ccache_zero:
         description: Zeroes out the ccache stats

--- a/boulder/data/macros/actions/cmake.yaml
+++ b/boulder/data/macros/actions/cmake.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 actions:
 
     - cmake:

--- a/boulder/data/macros/actions/meson.yaml
+++ b/boulder/data/macros/actions/meson.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 actions:
 
     - meson:

--- a/boulder/data/macros/actions/misc.yaml
+++ b/boulder/data/macros/actions/misc.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 actions:
 
     - export_docbook_catalogs:

--- a/boulder/data/macros/actions/ninja.yaml
+++ b/boulder/data/macros/actions/ninja.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 actions:
     - ninja:
         description: Use ninja, without any additional arguments this will run the default target (likely the build)

--- a/boulder/data/macros/actions/perl.yaml
+++ b/boulder/data/macros/actions/perl.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 actions:
     - perl_setup:
         description: Create a Makefile with ExtUtils::MakeMaker from stdlib to be used with %make and %make_install macros

--- a/boulder/data/macros/actions/pgo.yaml
+++ b/boulder/data/macros/actions/pgo.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 definitions:
     - pgo_stage : "%(pgo_stage)"
 

--- a/boulder/data/macros/actions/python.yaml
+++ b/boulder/data/macros/actions/python.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 actions:
 
     - python_setup:

--- a/boulder/data/macros/actions/qt-kde.yaml
+++ b/boulder/data/macros/actions/qt-kde.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 actions:
     - qmake_qt5:
         description: Invokes Qt5 with the correct default values

--- a/boulder/data/macros/actions/ruby.yaml
+++ b/boulder/data/macros/actions/ruby.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 actions:
     - gem_build:
         description: Build a ruby gem

--- a/boulder/data/macros/arch/aarch64.yaml
+++ b/boulder/data/macros/arch/aarch64.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 # Provides -m64 builds for aarch64 build-hosts
 
 definitions:

--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 # Provides core definitions which each profile may override
 
 definitions:

--- a/boulder/data/macros/arch/emul32/x86_64.yaml
+++ b/boulder/data/macros/arch/emul32/x86_64.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 # Provides -m32 builds for x86_64 build-hosts
 
 definitions:

--- a/boulder/data/macros/arch/riscv64.yaml
+++ b/boulder/data/macros/arch/riscv64.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 # Provides -m64 builds for riscv64 build-hosts
 
 definitions:

--- a/boulder/data/macros/arch/x86.yaml
+++ b/boulder/data/macros/arch/x86.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 # Provides -m32 builds for i686 build-hosts
 
 definitions:

--- a/boulder/data/macros/arch/x86_64-stage1.yaml
+++ b/boulder/data/macros/arch/x86_64-stage1.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 # Based on x86_64 - provides the stage1 bootstrap definitions
 # We force a new cross compilation step into existence with
 # our "-xvendorID"

--- a/boulder/data/macros/arch/x86_64-v3x.yaml
+++ b/boulder/data/macros/arch/x86_64-v3x.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 # Provides -m64 builds for x86_64-v3x build-hosts
 
 definitions:

--- a/boulder/data/macros/arch/x86_64.yaml
+++ b/boulder/data/macros/arch/x86_64.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 # Provides -m64 builds for x86_64 build-hosts
 
 definitions:

--- a/boulder/data/profile.d/default-x86_64.yaml
+++ b/boulder/data/profile.d/default-x86_64.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 default-x86_64:
   repositories:
     volatile:

--- a/boulder/data/recipeTemplate.yaml
+++ b/boulder/data/recipeTemplate.yaml
@@ -1,8 +1,5 @@
-#
-# SPDX-FileCopyrightText: © 2025- AerynOS Developers
-#
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
 # SPDX-License-Identifier: MPL-2.0
-#
 name        : %s
 version     : %s
 release     : %s

--- a/boulder/src/architecture.rs
+++ b/boulder/src/architecture.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use derive_more::Display;

--- a/boulder/src/build.rs
+++ b/boulder/src/build.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{

--- a/boulder/src/build/job.rs
+++ b/boulder/src/build/job.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2026 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{

--- a/boulder/src/build/job/phase.rs
+++ b/boulder/src/build/job/phase.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2026 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use itertools::Itertools;

--- a/boulder/src/build/pgo.rs
+++ b/boulder/src/build/pgo.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use stone_recipe::tuning::Toolchain;

--- a/boulder/src/build/root.rs
+++ b/boulder/src/build/root.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2026 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::collections::BTreeSet;

--- a/boulder/src/cli.rs
+++ b/boulder/src/cli.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 use std::path::PathBuf;
 

--- a/boulder/src/cli/build.rs
+++ b/boulder/src/cli/build.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::io;

--- a/boulder/src/cli/chroot.rs
+++ b/boulder/src/cli/chroot.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{io, path::PathBuf, process};

--- a/boulder/src/cli/profile.rs
+++ b/boulder/src/cli/profile.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{collections::BTreeMap, io};

--- a/boulder/src/cli/recipe.rs
+++ b/boulder/src/cli/recipe.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2026 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 use std::{
     io::{self, Read},

--- a/boulder/src/cli/version.rs
+++ b/boulder/src/cli/version.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use clap::Parser;

--- a/boulder/src/container.rs
+++ b/boulder/src/container.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use container::Container;

--- a/boulder/src/draft.rs
+++ b/boulder/src/draft.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::path::Path;

--- a/boulder/src/draft/build.rs
+++ b/boulder/src/draft/build.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 use std::collections::{BTreeMap, BTreeSet};
 use std::{fmt, num::NonZeroU64};

--- a/boulder/src/draft/build/autotools.rs
+++ b/boulder/src/draft/build/autotools.rs
@@ -4,8 +4,7 @@ use fs_err as fs;
 use moss::{Dependency, dependency};
 use regex::Regex;
 
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 use crate::draft::File;
 use crate::draft::build::{Error, Phases, State};

--- a/boulder/src/draft/build/cargo.rs
+++ b/boulder/src/draft/build/cargo.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 use crate::draft::File;
 use crate::draft::build::{Error, Phases, State};

--- a/boulder/src/draft/build/cmake.rs
+++ b/boulder/src/draft/build/cmake.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use regex::Regex;

--- a/boulder/src/draft/build/meson.rs
+++ b/boulder/src/draft/build/meson.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 use std::path::Path;
 

--- a/boulder/src/draft/build/perl.rs
+++ b/boulder/src/draft/build/perl.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2025 Aeryn OS Developers
-//
+// SPDX-FileCopyrightText: 2025 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 pub mod extutils_makefile {

--- a/boulder/src/draft/build/python.rs
+++ b/boulder/src/draft/build/python.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 pub mod pep517 {

--- a/boulder/src/draft/build/ruby.rs
+++ b/boulder/src/draft/build/ruby.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2025 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 // filename.gem

--- a/boulder/src/draft/licenses.rs
+++ b/boulder/src/draft/licenses.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2025 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use fs_err as fs;

--- a/boulder/src/draft/metadata.rs
+++ b/boulder/src/draft/metadata.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use itertools::Itertools;

--- a/boulder/src/draft/metadata/basic.rs
+++ b/boulder/src/draft/metadata/basic.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use moss::util;

--- a/boulder/src/draft/metadata/github.rs
+++ b/boulder/src/draft/metadata/github.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use regex::Regex;

--- a/boulder/src/draft/metadata/gitlab.rs
+++ b/boulder/src/draft/metadata/gitlab.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2026 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use regex::Regex;

--- a/boulder/src/draft/metadata/metacpan.rs
+++ b/boulder/src/draft/metadata/metacpan.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2025 Aeryn OS Developers
-//
+// SPDX-FileCopyrightText: 2025 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use regex::Regex;

--- a/boulder/src/draft/metadata/pypi.rs
+++ b/boulder/src/draft/metadata/pypi.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2025 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use moss::util;

--- a/boulder/src/draft/monitoring.rs
+++ b/boulder/src/draft/monitoring.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2024 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2025 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::io;

--- a/boulder/src/draft/upstream.rs
+++ b/boulder/src/draft/upstream.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 use std::{
     io,
     path::{Path, PathBuf},

--- a/boulder/src/env.rs
+++ b/boulder/src/env.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{

--- a/boulder/src/macros.rs
+++ b/boulder/src/macros.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::collections::BTreeMap;

--- a/boulder/src/main.rs
+++ b/boulder/src/main.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 mod architecture;

--- a/boulder/src/package.rs
+++ b/boulder/src/package.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 use std::collections::{BTreeMap, btree_map};
 use std::{io, num::NonZeroU64};

--- a/boulder/src/package/analysis.rs
+++ b/boulder/src/package/analysis.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::collections::BTreeMap;

--- a/boulder/src/package/analysis/handler.rs
+++ b/boulder/src/package/analysis/handler.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 use filetime::FileTime;
 use itertools::Itertools;
 use std::{

--- a/boulder/src/package/analysis/handler/elf.rs
+++ b/boulder/src/package/analysis/handler/elf.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 use std::{
     ffi::CStr,
     path::{Path, PathBuf},

--- a/boulder/src/package/analysis/handler/python.rs
+++ b/boulder/src/package/analysis/handler/python.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 use std::process::{Command, Stdio};
 
 use fs_err as fs;

--- a/boulder/src/package/analysis/scripts/get-py-deps.py
+++ b/boulder/src/package/analysis/scripts/get-py-deps.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: Copyright © 2025 Serpent OS Developers
-#
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
 # SPDX-License-Identifier: MPL-2.0
 
 import argparse

--- a/boulder/src/package/collect.rs
+++ b/boulder/src/package/collect.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 use std::{
     ffi::OsStr,

--- a/boulder/src/package/emit.rs
+++ b/boulder/src/package/emit.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 use std::{
     io::{self, Write},

--- a/boulder/src/package/emit/manifest.rs
+++ b/boulder/src/package/emit/manifest.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{

--- a/boulder/src/package/emit/manifest/binary.rs
+++ b/boulder/src/package/emit/manifest/binary.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{collections::BTreeSet, io::Write};

--- a/boulder/src/package/emit/manifest/json.rs
+++ b/boulder/src/package/emit/manifest/json.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{

--- a/boulder/src/paths.rs
+++ b/boulder/src/paths.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{io, path::PathBuf};

--- a/boulder/src/profile.rs
+++ b/boulder/src/profile.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use derive_more::Debug;

--- a/boulder/src/recipe.rs
+++ b/boulder/src/recipe.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{

--- a/boulder/src/timing.rs
+++ b/boulder/src/timing.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 use std::{
     collections::BTreeMap,
     fmt,

--- a/boulder/src/upstream.rs
+++ b/boulder/src/upstream.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2026 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2026 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{io, path::Path, time::Duration};

--- a/boulder/src/upstream/git.rs
+++ b/boulder/src/upstream/git.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2026 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2026 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{

--- a/boulder/src/upstream/plain.rs
+++ b/boulder/src/upstream/plain.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2026 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2026 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{

--- a/crates/astr/Cargo.toml
+++ b/crates/astr/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 [package]
 name = "astr"
 version.workspace = true

--- a/crates/astr/src/cow.rs
+++ b/crates/astr/src/cow.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 use std::ops::Deref;
 
 use super::AStr;

--- a/crates/astr/src/diesel.rs
+++ b/crates/astr/src/diesel.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 use diesel::{
     Queryable,
     deserialize::{FromSql, Result},

--- a/crates/astr/src/lib.rs
+++ b/crates/astr/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 use std::{
     borrow::{Borrow, Cow},
     fmt,

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 [package]
 name = "config"
 edition.workspace = true

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{

--- a/crates/container/Cargo.toml
+++ b/crates/container/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 [package]
 name = "container"
 edition.workspace = true

--- a/crates/container/README.md
+++ b/crates/container/README.md
@@ -1,3 +1,8 @@
+---
+# SPDX-FileCopyrightText: 2023 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+---
+
 # container
 
 container is a crate to start a basic rootless container. Its goal is to create a safe and isolated environment where to build and/or test packages. Environment isolation is desired in that:

--- a/crates/container/src/idmap.rs
+++ b/crates/container/src/idmap.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::process::Command;

--- a/crates/container/src/lib.rs
+++ b/crates/container/src/lib.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::io;

--- a/crates/dag/Cargo.toml
+++ b/crates/dag/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 [package]
 name = "dag"
 edition.workspace = true

--- a/crates/dag/src/lib.rs
+++ b/crates/dag/src/lib.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use petgraph::{

--- a/crates/dag/src/subgraph.rs
+++ b/crates/dag/src/subgraph.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use petgraph::{EdgeType, prelude::Graph, stable_graph::IndexType, visit::Dfs};

--- a/crates/fnmatch/Cargo.toml
+++ b/crates/fnmatch/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 [package]
 name = "fnmatch"
 edition.workspace = true

--- a/crates/fnmatch/src/lib.rs
+++ b/crates/fnmatch/src/lib.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 //! Use fnmatch to generate regex matchers from glob-style strings.

--- a/crates/stone/Cargo.toml
+++ b/crates/stone/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 [package]
 name = "stone"
 edition.workspace = true

--- a/crates/stone/benches/read.rs
+++ b/crates/stone/benches/read.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{

--- a/crates/stone/src/ext.rs
+++ b/crates/stone/src/ext.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 use std::io::{Read, Result, Write};
 

--- a/crates/stone/src/header/mod.rs
+++ b/crates/stone/src/header/mod.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::io::{self, Read, Write};

--- a/crates/stone/src/header/v1.rs
+++ b/crates/stone/src/header/v1.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use thiserror::Error;

--- a/crates/stone/src/lib.rs
+++ b/crates/stone/src/lib.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 pub(crate) mod ext;

--- a/crates/stone/src/payload/attribute.rs
+++ b/crates/stone/src/payload/attribute.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::io::{Read, Write};

--- a/crates/stone/src/payload/content.rs
+++ b/crates/stone/src/payload/content.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 #[derive(Debug)]

--- a/crates/stone/src/payload/index.rs
+++ b/crates/stone/src/payload/index.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::io::{Read, Write};

--- a/crates/stone/src/payload/layout.rs
+++ b/crates/stone/src/payload/layout.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::io::{Read, Write};

--- a/crates/stone/src/payload/meta.rs
+++ b/crates/stone/src/payload/meta.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::io::{Read, Write};

--- a/crates/stone/src/payload/mod.rs
+++ b/crates/stone/src/payload/mod.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 mod attribute;

--- a/crates/stone/src/read/digest.rs
+++ b/crates/stone/src/read/digest.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::io::Read;

--- a/crates/stone/src/read/mod.rs
+++ b/crates/stone/src/read/mod.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 #![allow(dead_code)]
 

--- a/crates/stone/src/read/zstd.rs
+++ b/crates/stone/src/read/zstd.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::io::{BufReader, Read, Result};

--- a/crates/stone/src/write.rs
+++ b/crates/stone/src/write.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::io::{self, Read, Seek, SeekFrom, Write};

--- a/crates/stone/src/write/digest.rs
+++ b/crates/stone/src/write/digest.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::io::Write;

--- a/crates/stone/src/write/zstd.rs
+++ b/crates/stone/src/write/zstd.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::io::{self, Result, Write};

--- a/crates/stone_recipe/Cargo.toml
+++ b/crates/stone_recipe/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 [package]
 name = "stone_recipe"
 edition.workspace = true

--- a/crates/stone_recipe/src/control_file.rs
+++ b/crates/stone_recipe/src/control_file.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 use std::{collections::BTreeMap, mem};
 
 use thiserror::Error;

--- a/crates/stone_recipe/src/lib.rs
+++ b/crates/stone_recipe/src/lib.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2026 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::collections::BTreeMap;

--- a/crates/stone_recipe/src/macros.rs
+++ b/crates/stone_recipe/src/macros.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use serde::Deserialize;

--- a/crates/stone_recipe/src/script.rs
+++ b/crates/stone_recipe/src/script.rs
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
+
 #![allow(clippy::map_collect_result_unit)]
 
 use nom::{

--- a/crates/stone_recipe/src/serde_util.rs
+++ b/crates/stone_recipe/src/serde_util.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 use serde::Deserialize;
 
 pub fn default_true() -> bool {

--- a/crates/stone_recipe/src/tuning.rs
+++ b/crates/stone_recipe/src/tuning.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use serde::Deserialize;

--- a/crates/stone_recipe/src/upstream.rs
+++ b/crates/stone_recipe/src/upstream.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2026 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2026 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{borrow::Borrow, collections::BTreeMap, fmt::Display, path::PathBuf, str::FromStr};

--- a/crates/tools_buildinfo/Cargo.toml
+++ b/crates/tools_buildinfo/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 [package]
 name = "tools_buildinfo"
 edition.workspace = true

--- a/crates/tools_buildinfo/build.rs
+++ b/crates/tools_buildinfo/build.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 // build.rs
 use std::os::unix::ffi::OsStringExt;
 

--- a/crates/tools_buildinfo/src/lib.rs
+++ b/crates/tools_buildinfo/src/lib.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2025 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use chrono::DateTime;

--- a/crates/tools_buildinfo/src/values.rs
+++ b/crates/tools_buildinfo/src/values.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2025 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 pub(crate) const VERSION: &str = env!("BUILDINFO_VERSION");

--- a/crates/tracing_common/Cargo.toml
+++ b/crates/tracing_common/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 [package]
 name = "tracing_common"
 edition.workspace = true

--- a/crates/tracing_common/src/lib.rs
+++ b/crates/tracing_common/src/lib.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2025 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 //! Common tracing utilities for moss and related tools

--- a/crates/tracing_common/src/logging.rs
+++ b/crates/tracing_common/src/logging.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2025 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 //! Tracing logging and configuration utilities

--- a/crates/triggers/Cargo.toml
+++ b/crates/triggers/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 [package]
 name = "triggers"
 edition.workspace = true

--- a/crates/triggers/src/format.rs
+++ b/crates/triggers/src/format.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 // [`Pattern`] has Regex inside which has interior mutability,

--- a/crates/triggers/src/lib.rs
+++ b/crates/triggers/src/lib.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 //! System trigger management facilities

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 [package]
 name = "tui"
 edition.workspace = true

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 pub use self::styled::Styled;

--- a/crates/tui/src/pretty.rs
+++ b/crates/tui/src/pretty.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 //! Pretty printing for moss CLI

--- a/crates/tui/src/styled.rs
+++ b/crates/tui/src/styled.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 use std::io::stdout;
 
 use crossterm::{style::Stylize, tty::IsTty};

--- a/crates/version_parse/Cargo.toml
+++ b/crates/version_parse/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 [package]
 name = "version_parse"
 edition.workspace = true

--- a/crates/version_parse/src/lib.rs
+++ b/crates/version_parse/src/lib.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2025 AerynOS Developers
-//
+// SPDX-FileCopyrightText: 2026 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 //! Version pattern extraction library for extracting version numbers and project names from file paths and URLs.

--- a/crates/vfs/Cargo.toml
+++ b/crates/vfs/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 [package]
 name = "vfs"
 version = "0.1.0"

--- a/crates/vfs/src/cache.rs
+++ b/crates/vfs/src/cache.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 //! Cache management (unpack to a store)

--- a/crates/vfs/src/lib.rs
+++ b/crates/vfs/src/lib.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 //! VFS assistance for moss including optimised tree + blit helpers

--- a/crates/vfs/src/path.rs
+++ b/crates/vfs/src/path.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 use std::ops::Deref;
 
 use astr::AStr;

--- a/crates/vfs/src/tree/builder.rs
+++ b/crates/vfs/src/tree/builder.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 //! Build a vfs tree incrementally

--- a/crates/vfs/src/tree/mod.rs
+++ b/crates/vfs/src/tree/mod.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 //! Virtual filesystem tree (optimise layout inserts)

--- a/crates/yaml/Cargo.toml
+++ b/crates/yaml/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 [package]
 name = "yaml"
 version = "0.1.0"

--- a/crates/yaml/src/lib.rs
+++ b/crates/yaml/src/lib.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 pub use self::updater::Updater;

--- a/crates/yaml/src/updater.rs
+++ b/crates/yaml/src/updater.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::ops;

--- a/justfile
+++ b/justfile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 # The default task is to build moss
 default: moss
 

--- a/libstone/Cargo.toml
+++ b/libstone/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 [package]
 name = "libstone"
 version.workspace = true

--- a/libstone/build.rs
+++ b/libstone/build.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 use std::path::Path;
 
 fn main() {

--- a/libstone/cbindgen.toml
+++ b/libstone/cbindgen.toml
@@ -3,8 +3,7 @@ language = "C"
 cpp_compat = true
 
 header = """
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 """
 

--- a/libstone/examples/read.c
+++ b/libstone/examples/read.c
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 #include <assert.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/libstone/src/lib.rs
+++ b/libstone/src/lib.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2024 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 #![allow(non_camel_case_types)]
 #![allow(clippy::disallowed_types)] // created with File::from_raw_fd, which fs-err doesn't have

--- a/libstone/src/payload.rs
+++ b/libstone/src/payload.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 use stone::{StoneDecodedPayload, StonePayloadHeader};
 
 pub use self::attribute::StonePayloadAttributeRecord;

--- a/libstone/src/payload/attribute.rs
+++ b/libstone/src/payload/attribute.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]

--- a/libstone/src/payload/index.rs
+++ b/libstone/src/payload/index.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]

--- a/libstone/src/payload/layout.rs
+++ b/libstone/src/payload/layout.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 use stone::{StonePayloadLayoutFile, StonePayloadLayoutFileType};
 

--- a/libstone/src/payload/meta.rs
+++ b/libstone/src/payload/meta.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 use stone::{StonePayloadMetaDependency, StonePayloadMetaTag};
 

--- a/libstone/src/stone.h
+++ b/libstone/src/stone.h
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 

--- a/licenses.sh
+++ b/licenses.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
 
 rm -rf license-list-data
 mkdir -p license-list-data/text

--- a/moss-filesystem-performance.md
+++ b/moss-filesystem-performance.md
@@ -1,3 +1,8 @@
+---
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+---
+
 # Moss vs. filesystem speed
 
 - i7-6700K@4.6GHz

--- a/moss/Cargo.toml
+++ b/moss/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 [package]
 name = "moss"
 edition.workspace = true

--- a/moss/src/cli/boot.rs
+++ b/moss/src/cli/boot.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use clap::{ArgMatches, Command};

--- a/moss/src/cli/cache.rs
+++ b/moss/src/cli/cache.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 use clap::{ArgMatches, Command};
 use moss::{Client, Installation, client, environment};
 use thiserror::Error;

--- a/moss/src/cli/extract.rs
+++ b/moss/src/cli/extract.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::path::PathBuf;

--- a/moss/src/cli/fetch.rs
+++ b/moss/src/cli/fetch.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2026 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::path::PathBuf;

--- a/moss/src/cli/index.rs
+++ b/moss/src/cli/index.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 use std::path::PathBuf;
 

--- a/moss/src/cli/info.rs
+++ b/moss/src/cli/info.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use clap::{ArgMatches, Command, arg};

--- a/moss/src/cli/inspect.rs
+++ b/moss/src/cli/inspect.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use clap::{ArgMatches, Command, arg};

--- a/moss/src/cli/install.rs
+++ b/moss/src/cli/install.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::path::PathBuf;

--- a/moss/src/cli/list.rs
+++ b/moss/src/cli/list.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use clap::{ArgMatches, Command, arg};

--- a/moss/src/cli/mod.rs
+++ b/moss/src/cli/mod.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{env, io, path::Path, path::PathBuf};

--- a/moss/src/cli/remove.rs
+++ b/moss/src/cli/remove.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use clap::{ArgMatches, Command, arg};

--- a/moss/src/cli/repo.rs
+++ b/moss/src/cli/repo.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{path::PathBuf, process};

--- a/moss/src/cli/search.rs
+++ b/moss/src/cli/search.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use clap::builder::NonEmptyStringValueParser;

--- a/moss/src/cli/search_file.rs
+++ b/moss/src/cli/search_file.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2025 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use clap::builder::NonEmptyStringValueParser;

--- a/moss/src/cli/state.rs
+++ b/moss/src/cli/state.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{

--- a/moss/src/cli/sync.rs
+++ b/moss/src/cli/sync.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::path::PathBuf;

--- a/moss/src/cli/version.rs
+++ b/moss/src/cli/version.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use clap::{ArgMatches, Command, arg};

--- a/moss/src/client/boot.rs
+++ b/moss/src/client/boot.rs
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-// SPDX-FileCopyrightText: Copyright © 2025 AerynOS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 //! Boot management integration in moss

--- a/moss/src/client/cache.rs
+++ b/moss/src/client/cache.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 //! Cache management for unpacking remote assets (`.stone`, etc.)

--- a/moss/src/client/extract.rs
+++ b/moss/src/client/extract.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 use std::{
     io::{self, Read, Seek, SeekFrom},
     path::{Path, PathBuf},

--- a/moss/src/client/fetch.rs
+++ b/moss/src/client/fetch.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 use std::{
     io,
     path::Path,

--- a/moss/src/client/index.rs
+++ b/moss/src/client/index.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 use std::{
     collections::{BTreeMap, btree_map},
     io,

--- a/moss/src/client/install.rs
+++ b/moss/src/client/install.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 //! Installation-specific code for several core moss operations

--- a/moss/src/client/mod.rs
+++ b/moss/src/client/mod.rs
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-// SPDX-FileCopyrightText: Copyright © 2025 AerynOS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 //! The core client implementation for the moss package manager

--- a/moss/src/client/postblit.rs
+++ b/moss/src/client/postblit.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 //! Operations that happen post-blit (primarily, triggers within container)

--- a/moss/src/client/prune.rs
+++ b/moss/src/client/prune.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 //! The pruning system for moss states and assets

--- a/moss/src/client/remove.rs
+++ b/moss/src/client/remove.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 use std::{
     collections::BTreeSet,
     time::{Duration, Instant},

--- a/moss/src/client/sync.rs
+++ b/moss/src/client/sync.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 use std::{
     collections::BTreeSet,
     path::{Path, PathBuf},

--- a/moss/src/client/verify.rs
+++ b/moss/src/client/verify.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{

--- a/moss/src/db/layout/diesel.toml
+++ b/moss/src/db/layout/diesel.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 # For documentation on how to configure this file,
 # see https://diesel.rs/guides/configuring-diesel-cli
 

--- a/moss/src/db/layout/migrations/2024-03-04-192634_init/down.sql
+++ b/moss/src/db/layout/migrations/2024-03-04-192634_init/down.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: 2024 AerynOS Developers
+-- SPDX-License-Identifier: MPL-2.0
+
 -- This file should undo anything in `up.sql`
 
 DROP TABLE IF EXISTS layout;

--- a/moss/src/db/layout/migrations/2024-03-04-192634_init/up.sql
+++ b/moss/src/db/layout/migrations/2024-03-04-192634_init/up.sql
@@ -1,7 +1,10 @@
+-- SPDX-FileCopyrightText: 2024 AerynOS Developers
+-- SPDX-License-Identifier: MPL-2.0
+
 -- Your SQL goes here
 
 CREATE TABLE IF NOT EXISTS layout (
-    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,  
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
     package_id TEXT NOT NULL,
     uid INTEGER NOT NULL,
     gid INTEGER NOT NULL,

--- a/moss/src/db/layout/mod.rs
+++ b/moss/src/db/layout/mod.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use astr::AStr;

--- a/moss/src/db/meta/diesel.toml
+++ b/moss/src/db/meta/diesel.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 # For documentation on how to configure this file,
 # see https://diesel.rs/guides/configuring-diesel-cli
 

--- a/moss/src/db/meta/migrations/2024-03-03-165811_init/down.sql
+++ b/moss/src/db/meta/migrations/2024-03-03-165811_init/down.sql
@@ -1,6 +1,9 @@
+-- SPDX-FileCopyrightText: 2024 AerynOS Developers
+-- SPDX-License-Identifier: MPL-2.0
+
 -- This file should undo anything in `up.sql`
 DROP TABLE IF EXISTS meta;
 DROP TABLE IF EXISTS meta_licenses;
-DROP TABLE IF EXISTS meta_dependencies; 
+DROP TABLE IF EXISTS meta_dependencies;
 DROP TABLE IF EXISTS meta_providers;
 DROP TABLE IF EXISTS meta_conflicts;

--- a/moss/src/db/meta/migrations/2024-03-03-165811_init/up.sql
+++ b/moss/src/db/meta/migrations/2024-03-03-165811_init/up.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: 2024 AerynOS Developers
+-- SPDX-License-Identifier: MPL-2.0
+
 -- Your SQL goes here
 CREATE TABLE IF NOT EXISTS meta (
     package TEXT NOT NULL PRIMARY KEY,

--- a/moss/src/db/meta/mod.rs
+++ b/moss/src/db/meta/mod.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/moss/src/db/mod.rs
+++ b/moss/src/db/mod.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{

--- a/moss/src/db/state/diesel.toml
+++ b/moss/src/db/state/diesel.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 # For documentation on how to configure this file,
 # see https://diesel.rs/guides/configuring-diesel-cli
 

--- a/moss/src/db/state/migrations/2024-03-04-201550_init/down.sql
+++ b/moss/src/db/state/migrations/2024-03-04-201550_init/down.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: 2024 AerynOS Developers
+-- SPDX-License-Identifier: MPL-2.0
+
 -- This file should undo anything in `up.sql`
 DROP TABLE IF EXISTS state;
 DROP TABLE IF EXISTS state_selections;

--- a/moss/src/db/state/migrations/2024-03-04-201550_init/up.sql
+++ b/moss/src/db/state/migrations/2024-03-04-201550_init/up.sql
@@ -1,7 +1,10 @@
+-- SPDX-FileCopyrightText: 2024 AerynOS Developers
+-- SPDX-License-Identifier: MPL-2.0
+
 -- Your SQL goes here
 
 CREATE TABLE IF NOT EXISTS state (
-    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,  
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
     type TEXT NOT NULL,
     created BIGINT NOT NULL DEFAULT (unixepoch()),
     summary TEXT NULL,
@@ -9,7 +12,7 @@ CREATE TABLE IF NOT EXISTS state (
 );
 
 CREATE TABLE IF NOT EXISTS state_selections (
-    state_id INTEGER NOT NULL,  
+    state_id INTEGER NOT NULL,
     package_id TEXT NOT NULL,
     explicit BOOLEAN NOT NULL,
     reason TEXT NULL,

--- a/moss/src/db/state/mod.rs
+++ b/moss/src/db/state/mod.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use chrono::{DateTime, Utc};

--- a/moss/src/dependency.rs
+++ b/moss/src/dependency.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 //! Moss (v1) dependency and provider types

--- a/moss/src/environment.rs
+++ b/moss/src/environment.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 pub const NAME: &str = env!("CARGO_PKG_NAME");

--- a/moss/src/installation.rs
+++ b/moss/src/installation.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 //! Encapsulation of a target installation filesystem

--- a/moss/src/installation/lockfile.rs
+++ b/moss/src/installation/lockfile.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{

--- a/moss/src/lib.rs
+++ b/moss/src/lib.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 pub use self::client::Client;

--- a/moss/src/main.rs
+++ b/moss/src/main.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::error::Error;

--- a/moss/src/package/meta.rs
+++ b/moss/src/package/meta.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::collections::BTreeSet;

--- a/moss/src/package/mod.rs
+++ b/moss/src/package/mod.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::borrow::Borrow;

--- a/moss/src/package/render.rs
+++ b/moss/src/package/render.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::io::Write;

--- a/moss/src/registry/mod.rs
+++ b/moss/src/registry/mod.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 //! Defines an encapsulation of "query plugins", including an interface

--- a/moss/src/registry/plugin/active.rs
+++ b/moss/src/registry/plugin/active.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use log::warn;

--- a/moss/src/registry/plugin/cobble.rs
+++ b/moss/src/registry/plugin/cobble.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::collections::BTreeMap;

--- a/moss/src/registry/plugin/mod.rs
+++ b/moss/src/registry/plugin/mod.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 //! Defines the notion of a registry plugin, which can be added to the

--- a/moss/src/registry/plugin/repository.rs
+++ b/moss/src/registry/plugin/repository.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use log::warn;

--- a/moss/src/registry/transaction.rs
+++ b/moss/src/registry/transaction.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::collections::HashMap;

--- a/moss/src/repository/manager.rs
+++ b/moss/src/repository/manager.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::collections::BTreeMap;

--- a/moss/src/repository/mod.rs
+++ b/moss/src/repository/mod.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::collections::BTreeMap;

--- a/moss/src/request.rs
+++ b/moss/src/request.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{

--- a/moss/src/runtime.rs
+++ b/moss/src/runtime.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::future::Future;

--- a/moss/src/signal.rs
+++ b/moss/src/signal.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 //! Signal handling

--- a/moss/src/state.rs
+++ b/moss/src/state.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::io::Write;

--- a/moss/src/system_model.rs
+++ b/moss/src/system_model.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 use std::path::Path;
 use std::{collections::BTreeSet, io};
 

--- a/moss/src/system_model/decode.rs
+++ b/moss/src/system_model/decode.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 use kdl::{KdlDocument, KdlNode, KdlValue};
 use thiserror::Error;
 

--- a/moss/src/system_model/encode.rs
+++ b/moss/src/system_model/encode.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 use kdl::{KdlDocument, KdlEntry, KdlNode, KdlValue};
 
 use crate::{Provider, Repository, repository};

--- a/moss/src/system_model/update.rs
+++ b/moss/src/system_model/update.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 use std::collections::BTreeSet;
 
 use kdl::{FormatConfig, KdlDocument, KdlNode, KdlNodeFormat};

--- a/moss/src/util.rs
+++ b/moss/src/util.rs
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
-//
+// SPDX-FileCopyrightText: 2026 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{

--- a/stone.xml
+++ b/stone.xml
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2024 AerynOS Developers
+SPDX-License-Identifier: MPL-2.0
+-->
+
 <?xml version="1.0" encoding="UTF-8"?>
 <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
   <!-- Base stone container type -->

--- a/test/base.yml
+++ b/test/base.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 # Provides core definitions which each profile may override
 
 definitions:

--- a/test/boulder-stone.yml
+++ b/test/boulder-stone.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 name        : boulder
 version     : 1.0.1
 release     : 35

--- a/test/cmake.yml
+++ b/test/cmake.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 actions:
 
     - cmake:

--- a/test/conflicts/italian-pizza.yml
+++ b/test/conflicts/italian-pizza.yml
@@ -1,5 +1,4 @@
-#
-# SPDX-FileCopyrightText: © 2020-2022 Serpent OS Developers
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
 #
 # SPDX-License-Identifier: Zlib
 #

--- a/test/conflicts/pineapple.yml
+++ b/test/conflicts/pineapple.yml
@@ -1,5 +1,4 @@
-#
-# SPDX-FileCopyrightText: © 2020-2022 Serpent OS Developers
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
 #
 # SPDX-License-Identifier: Zlib
 #

--- a/test/llvm-stone.yml
+++ b/test/llvm-stone.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 # TODO: Split out clang/etc and build statically against llvm package!
 name        : llvm
 version     : 16.0.4

--- a/test/trigger.yml
+++ b/test/trigger.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 name: depmod
 description: |
     Needlessly verbose example to show how we could utilise YAML to make

--- a/test/x86_64.yml
+++ b/test/x86_64.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 # Provides -m64 builds for x86_64 build-hosts
 
 definitions:


### PR DESCRIPTION
For transparency, I used this script to replace the current copyright header with the format we agreed upon (that is `SPDX-FileCopyrightText: <file_creation_year> AerynOS Developers`)

```shell
#!/bin/sh

files=$(find . -type f -not -path './.git/*')
for f in $files; do
    echo $f
    year=$(date -d @$(git log --reverse --follow --format='%at' "$f" | head -n1) +%Y)
    sed "s|\(.*SPDX-FileCopyrightText: \).*|\1$year AerynOS Developers|" -i "$f"
done
```

This PR solves #714.