### PR TITLE
moss/search: Improve search and `provides` commands

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
         run: cargo build
 
       - name: Test project
-        run: cargo test --all
+        run: cargo test --all --features moss/testing
 
       - name: Run clippy
         uses: giraffate/clippy-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ typos
 **/db/**/test.db
 
 .root
+aosroot/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2079,6 +2079,7 @@ dependencies = [
  "snafu",
  "stone",
  "strum",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",

--- a/README.md
+++ b/README.md
@@ -95,22 +95,19 @@ location of the boulder data files (which live in ${HOME}/.local/share/boulder i
 alias boulder="${HOME}/.local/bin/boulder --data-dir=${HOME}/.local/share/boulder/ --config-dir=${HOME}/.config/boulder/ --moss-root=${HOME}/.cache/boulder/"
 ```
 
-
 ## 📚 Documentation
 
 See [aerynos.dev](https://aerynos.dev/).
-
 
 ## 🧪 Experiment
 
 **NB:** Remember to use the `-D aosroot/` argument to specify a root directory, otherwise moss will happily
 eat your current operating system.
 
-
 ```bash
 just get-started
 
-# create the sosroot/ directory
+# create the aosroot/ directory
 mkdir -pv aosroot/
 
 # Add the unstable repo

--- a/justfile
+++ b/justfile
@@ -81,7 +81,7 @@ lint:
 # Run tests
 test: lint
   @echo "Running tests in all packages…"
-  cargo test --all
+  cargo test --all --features moss/testing
 
 # Run all DB migrations
 migrate: (diesel "meta" "migration run") (diesel "layout" "migration run") (diesel "state" "migration run")

--- a/moss/Cargo.toml
+++ b/moss/Cargo.toml
@@ -7,6 +7,9 @@ edition.workspace = true
 version.workspace = true
 rust-version.workspace = true
 
+[features]
+testing = []
+
 [dependencies]
 config = { path = "../crates/config" }
 container = { path = "../crates/container" }
@@ -53,6 +56,9 @@ url.workspace = true
 xxhash-rust.workspace = true
 zbus.workspace = true
 astr = { workspace = true, features = ["diesel"] }
+
+[dev-dependencies]
+tempfile.workspace = true
 
 [package.metadata.cargo-machete]
 # Needed for unixepoch() in src/db/state/migrations/2025-03-04-201550_init/up.sql

--- a/moss/src/cli/search.rs
+++ b/moss/src/cli/search.rs
@@ -38,7 +38,22 @@ pub fn command() -> Command {
             Arg::new(FLAG_PROVIDES)
                 .short('p')
                 .long("provides")
-                .num_args(0)
+                .num_args(0..=1)
+                .require_equals(true)
+                .default_missing_value("binaries")
+                .value_parser([
+                    "binaries",
+                    "library",
+                    "name",
+                    "soname",
+                    "pkgconfig",
+                    "interpreter",
+                    "cmake",
+                    "python",
+                    "binary",
+                    "sysbinary",
+                    "pkgconfig32",
+                ])
                 .help("Search for packages providing a binary"),
         )
 }
@@ -46,7 +61,8 @@ pub fn command() -> Command {
 pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error> {
     let keyword = args.get_one::<String>(ARG_KEYWORD).unwrap();
     let only_installed = args.get_flag(FLAG_INSTALLED);
-    let provides = args.get_flag(FLAG_PROVIDES);
+    // let provides = args.get_flag(FLAG_PROVIDES);
+    let provides = args.get_one::<String>(FLAG_PROVIDES).map(|s| s.as_str());
 
     let client = Client::new(environment::NAME, installation)?;
     let flags = if only_installed {
@@ -55,8 +71,8 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
         package::Flags::new().with_available()
     };
 
-    let output = if provides {
-        provides_package(&client, flags, keyword)
+    let output = if let Some(provider) = provides {
+        provides_package(&client, flags, provider, keyword)
     } else {
         search_packages(&client, flags, keyword)
     };
@@ -90,7 +106,7 @@ fn search_packages(client: &Client, flags: package::Flags, keyword: &str) -> Vec
     }
 }
 
-fn search_providing_packages_by_kind(
+fn provides_package_by_kind(
     client: &Client,
     flags: package::Flags,
     name: &str,
@@ -103,14 +119,23 @@ fn search_providing_packages_by_kind(
     client.lookup_packages_by_provider(&provider, flags)
 }
 
-fn provides_package(client: &Client, flags: package::Flags, name: &str) -> Vec<Output> {
-    // We need to search both Binary and SystemBinary for possible programs
-    // TODO: Could include shared libraries down the line, maybe with a flag
-    [dependency::Kind::Binary, dependency::Kind::SystemBinary]
-        .into_iter()
-        .flat_map(|kind| search_providing_packages_by_kind(client, flags, name, kind))
-        .map(Output::from)
-        .collect()
+fn provides_package(client: &Client, flags: package::Flags, provider: &str, name: &str) -> Vec<Output> {
+    let packages = match provider.parse::<dependency::Kind>() {
+        Ok(kind) => provides_package_by_kind(client, flags, name, kind),
+        Err(_) => match provider {
+            // Default search with no argument to `--provides`
+            "binaries" => [dependency::Kind::Binary, dependency::Kind::SystemBinary]
+                .into_iter()
+                .flat_map(|kind| provides_package_by_kind(client, flags, name, kind))
+                .collect(),
+            "library" => provides_package_by_kind(client, flags, name, dependency::Kind::SharedLibrary),
+            _ => {
+                println!("Provider not recognized: {provider}");
+                vec![]
+            }
+        },
+    };
+    packages.into_iter().map(Output::from).collect()
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -223,7 +248,7 @@ mod tests {
             );
 
             // We can find hits for all these binaries with the `--provides` flag
-            let output = provides_package(client, flags, binary_name);
+            let output = provides_package(client, flags, "binaries", binary_name);
             assert!(
                 !output.is_empty(),
                 "`search --provides {binary_name} should not be empty"
@@ -258,7 +283,7 @@ mod tests {
         let client = test_client!();
         let flags = package::Flags::new().with_available();
         for binary_name in ["hx", "telnet", "toast"] {
-            let output_a = provides_package(client, flags, binary_name);
+            let output_a = provides_package(client, flags, "binaries", binary_name);
             let provider_syntax = format!("binary({binary_name})");
             let output_b = search_packages(client, flags, &provider_syntax);
             assert_eq!(output_a, output_b);

--- a/moss/src/cli/search.rs
+++ b/moss/src/cli/search.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
+use std::collections::BTreeMap;
+
 use clap::builder::NonEmptyStringValueParser;
 use clap::{Arg, ArgMatches, Command};
 
@@ -8,6 +10,7 @@ use moss::client;
 use moss::dependency;
 use moss::package::{self, Name};
 use moss::{Client, Installation, Provider, environment};
+use strum::Display;
 use tui::Styled;
 use tui::pretty::{ColumnDisplay, print_columns};
 
@@ -40,9 +43,8 @@ pub fn command() -> Command {
                 .long("provides")
                 .num_args(0..=1)
                 .require_equals(true)
-                .default_missing_value("binaries")
+                .default_missing_value("binary")
                 .value_parser([
-                    "binaries",
                     "library",
                     "name",
                     "soname",
@@ -54,15 +56,37 @@ pub fn command() -> Command {
                     "sysbinary",
                     "pkgconfig32",
                 ])
-                .help("Search for packages providing a binary"),
+                .help("Search for packages by provider"),
         )
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Display)]
+#[strum(serialize_all = "lowercase")]
+enum MatchKind {
+    Name,
+    Summary,
+}
+
+fn map_aliases(value: &str) -> &str {
+    match value {
+        "library" => "soname",
+        _ => value,
+    }
 }
 
 pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error> {
     let keyword = args.get_one::<String>(ARG_KEYWORD).unwrap();
     let only_installed = args.get_flag(FLAG_INSTALLED);
-    // let provides = args.get_flag(FLAG_PROVIDES);
-    let provides = args.get_one::<String>(FLAG_PROVIDES).map(|s| s.as_str());
+    let provider_kind = args
+        .get_one::<String>(FLAG_PROVIDES)
+        .map(|s| map_aliases(s))
+        .map(|s| s.parse::<dependency::Kind>().expect("clap should restrict input"));
+    let provider = Provider::from_name(keyword)
+        .map_err(|_| Error::ParseError(keyword.to_owned()))
+        .map(|provider| Provider {
+            kind: provider_kind.unwrap_or(provider.kind),
+            ..provider
+        })?;
 
     let client = Client::new(environment::NAME, installation)?;
     let flags = if only_installed {
@@ -71,80 +95,74 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
         package::Flags::new().with_available()
     };
 
-    let output = if let Some(provider) = provides {
-        provides_package(&client, flags, provider, keyword)
-    } else {
-        search_packages(&client, flags, keyword)
-    };
+    let mut output = match provider {
+        Provider {
+            kind: dependency::Kind::PackageName,
+            name: _name,
+        } => search_packages(&client, flags, keyword),
+        Provider {
+            kind: _kind,
+            name: ref _name,
+        } => provides_package(&client, flags, provider),
+    }?;
 
-    if output.is_empty() {
+    if output.values().all(|pkgs| pkgs.is_empty()) {
         return Ok(());
     }
 
-    print_columns(&output, 1);
+    for (match_kind, value) in output.iter_mut() {
+        println!("Matched field: {match_kind}");
+        value.sort();
+        print_columns(value, 1);
+    }
 
     Ok(())
 }
 
-fn search_packages(client: &Client, flags: package::Flags, keyword: &str) -> Vec<Output> {
-    let provider = Provider::from_name(keyword).expect("Invalid format");
-
-    match provider.kind {
-        dependency::Kind::PackageName => client
-            .search_packages(&provider.name, flags)
-            .map(|pkg| Output {
-                name: pkg.meta.name,
-                summary: pkg.meta.summary,
-                search_match: Some(keyword.to_owned()),
-            })
-            .collect(),
-        _ => client
-            .lookup_packages_by_provider(&provider, flags)
-            .into_iter()
-            .map(Output::from)
-            .collect(),
-    }
-}
-
-fn provides_package_by_kind(
+fn search_packages(
     client: &Client,
     flags: package::Flags,
-    name: &str,
-    kind: dependency::Kind,
-) -> Vec<package::Package> {
-    let provider = Provider {
-        kind,
-        name: name.to_owned(),
-    };
-    client.lookup_packages_by_provider(&provider, flags)
+    keyword: &str,
+) -> Result<BTreeMap<MatchKind, Vec<Output>>, Error> {
+    let mut output_kind: BTreeMap<MatchKind, Vec<Output>> = BTreeMap::new();
+
+    for pkg in client.search_packages(keyword, flags) {
+        let pkg_name_lowercase = pkg.meta.name.as_str().to_ascii_lowercase();
+        let match_kind = if pkg_name_lowercase.contains(&keyword.to_ascii_lowercase()) {
+            MatchKind::Name
+        } else {
+            MatchKind::Summary
+        };
+        output_kind.entry(match_kind).or_default().push(Output {
+            name: pkg.meta.name,
+            summary: pkg.meta.summary,
+            search_match: Some(keyword.to_owned()),
+        });
+    }
+    Ok(output_kind)
 }
 
-fn provides_package(client: &Client, flags: package::Flags, provider: &str, name: &str) -> Vec<Output> {
-    let packages = match provider.parse::<dependency::Kind>() {
-        Ok(kind) => provides_package_by_kind(client, flags, name, kind),
-        Err(_) => match provider {
-            // Default search with no argument to `--provides`
-            "binaries" => [dependency::Kind::Binary, dependency::Kind::SystemBinary]
-                .into_iter()
-                .flat_map(|kind| provides_package_by_kind(client, flags, name, kind))
-                .collect(),
-            "library" => provides_package_by_kind(client, flags, name, dependency::Kind::SharedLibrary),
-            _ => {
-                println!("Provider not recognized: {provider}");
-                vec![]
-            }
-        },
-    };
-    packages.into_iter().map(Output::from).collect()
+fn provides_package(
+    client: &Client,
+    flags: package::Flags,
+    provider: Provider,
+) -> Result<BTreeMap<MatchKind, Vec<Output>>, Error> {
+    let mut result: BTreeMap<MatchKind, Vec<Output>> = BTreeMap::new();
+    let packages = client.lookup_packages_by_provider(&provider, flags);
+    result.insert(MatchKind::Name, packages.into_iter().map(Output::from).collect());
+    Ok(result)
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("client")]
     Client(#[from] client::Error),
+
+    #[error("Invalid dependency type: {0}")]
+    ParseError(String),
 }
 
-#[cfg_attr(test, derive(Debug, PartialEq))] // Only derive these traits in test suite
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct Output {
     name: Name,
     summary: String,
@@ -152,7 +170,7 @@ struct Output {
 }
 
 fn highlight_string(content: &str, expression: &str) -> (String, String, String) {
-    if let Some(index) = content.find(expression) {
+    if let Some(index) = content.to_ascii_lowercase().find(&expression.to_ascii_lowercase()) {
         let (prefix, body) = content.split_at(index);
         let (matched, suffix) = body.split_at(expression.len());
         (prefix.to_owned(), matched.to_owned(), suffix.to_owned())
@@ -160,15 +178,16 @@ fn highlight_string(content: &str, expression: &str) -> (String, String, String)
         (content.to_owned(), String::default(), String::default())
     }
 }
+
 impl ColumnDisplay for Output {
     fn get_display_width(&self) -> usize {
         self.name.as_str().chars().count()
     }
 
     fn display_column(&self, writer: &mut impl std::io::prelude::Write, _col: tui::pretty::Column, width: usize) {
-        if let Some(expression) = self.search_match.clone() {
-            let (name_prefix, name_matched, name_suffix) = highlight_string(self.name.as_str(), &expression);
-            let (summary_prefix, summary_matched, summary_suffix) = highlight_string(&self.summary, &expression);
+        if let Some(expression) = self.search_match.as_deref() {
+            let (name_prefix, name_matched, name_suffix) = highlight_string(self.name.as_str(), expression);
+            let (summary_prefix, summary_matched, summary_suffix) = highlight_string(&self.summary, expression);
             let _ = write!(
                 writer,
                 " {}{}{}{:width$}  {}{}{}",
@@ -231,7 +250,7 @@ mod tests {
     fn test_find_packages() {
         let client = test_client!();
         let flags = package::Flags::new().with_available();
-        let output = search_packages(client, flags, "jq");
+        let output = search_packages(client, flags, "jq").unwrap();
         assert!(!output.is_empty(), "expected match for package jq");
     }
 
@@ -241,14 +260,14 @@ mod tests {
         let flags = package::Flags::new().with_available();
         for binary_name in ["telnet", "toast", "zramctl"] {
             // These binary names don't appear when searching by package name
-            let output = search_packages(client, flags, binary_name);
+            let output = search_packages(client, flags, binary_name).unwrap();
             assert!(
                 output.is_empty(),
                 "`search {binary_name}` output is not empty: {output:?}"
             );
 
             // We can find hits for all these binaries with the `--provides` flag
-            let output = provides_package(client, flags, "binaries", binary_name);
+            let output = provides_package(client, flags, "binaries", binary_name).unwrap();
             assert!(
                 !output.is_empty(),
                 "`search --provides {binary_name} should not be empty"
@@ -262,7 +281,7 @@ mod tests {
         let flags = package::Flags::new().with_available();
         for binary_name in ["telnet", "toast"] {
             // These binary names don't appear when searching by package name
-            let output = search_packages(client, flags, binary_name);
+            let output = search_packages(client, flags, binary_name).unwrap();
             assert!(
                 output.is_empty(),
                 "`search {binary_name}` output is not empty: {output:?}"
@@ -270,7 +289,7 @@ mod tests {
 
             // We can find hits for all these binaries with the provider syntax
             let provider_syntax = format!("binary({binary_name})");
-            let output = search_packages(client, flags, &provider_syntax);
+            let output = search_packages(client, flags, &provider_syntax).unwrap();
             assert!(
                 !output.is_empty(),
                 "`search {provider_syntax}` output should not be empty"
@@ -283,9 +302,9 @@ mod tests {
         let client = test_client!();
         let flags = package::Flags::new().with_available();
         for binary_name in ["hx", "telnet", "toast"] {
-            let output_a = provides_package(client, flags, "binaries", binary_name);
+            let output_a = provides_package(client, flags, "binaries", binary_name).unwrap();
             let provider_syntax = format!("binary({binary_name})");
-            let output_b = search_packages(client, flags, &provider_syntax);
+            let output_b = search_packages(client, flags, &provider_syntax).unwrap();
             assert_eq!(output_a, output_b);
         }
     }

--- a/moss/src/cli/search.rs
+++ b/moss/src/cli/search.rs
@@ -223,89 +223,247 @@ impl From<package::Package> for Output {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+
+    use moss::Registry;
+    use moss::package::{self, Name, Package};
+    use moss::registry::plugin;
+    use std::collections::BTreeSet;
     use std::sync::LazyLock;
 
     use super::*;
 
-    static TEST_CLIENT: LazyLock<Option<Client>> = LazyLock::new(|| {
-        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../aosroot");
-        let installation = Installation::open(root, None).ok()?;
-        Client::new("TEST", installation).ok()
+    fn pkg(name: &str, summary: &str, providers: BTreeSet<Provider>) -> Package {
+        Package {
+            id: package::Id::from(name.to_owned()),
+            meta: package::Meta {
+                name: Name::from(name.to_owned()),
+                summary: summary.to_owned(),
+                providers,
+                version_identifier: Default::default(),
+                source_release: Default::default(),
+                build_release: Default::default(),
+                architecture: Default::default(),
+                description: Default::default(),
+                source_id: Default::default(),
+                homepage: Default::default(),
+                licenses: Default::default(),
+                dependencies: Default::default(),
+                conflicts: Default::default(),
+                uri: Default::default(),
+                hash: Default::default(),
+                download_size: Default::default(),
+            },
+            flags: package::Flags::new().with_available(),
+        }
+    }
+
+    fn provider(kind: dependency::Kind, name: &str) -> Provider {
+        Provider {
+            kind,
+            name: name.to_owned(),
+        }
+    }
+
+    /// Build a test registry populated with real packages from the AerynOS recipes.
+    /// Package names, summaries, and provider metadata are sourced from stone.yaml
+    /// and manifest.x86_64.jsonc files in the recipes repository.
+    fn test_registry() -> Registry {
+        let mut registry = Registry::default();
+        let package_name = dependency::Kind::PackageName;
+        let binary = dependency::Kind::Binary;
+
+        let packages = vec![
+            pkg(
+                "git",
+                "Fast, scalable, distributed revision control system",
+                BTreeSet::from([provider(package_name, "git"), provider(binary, "git")]),
+            ),
+            pkg(
+                "jq",
+                "Command-line JSON processor",
+                BTreeSet::from([provider(package_name, "jq"), provider(binary, "jq")]),
+            ),
+            pkg(
+                "ripgrep",
+                "Recursive text search utility",
+                BTreeSet::from([provider(package_name, "ripgrep"), provider(binary, "rg")]),
+            ),
+            pkg(
+                "fd",
+                "A simple, fast and user-friendly alternative to find",
+                BTreeSet::from([provider(package_name, "fd"), provider(binary, "fd")]),
+            ),
+            pkg(
+                "nano",
+                "GNU Text Editor",
+                BTreeSet::from([
+                    provider(package_name, "nano"),
+                    provider(binary, "nano"),
+                    provider(binary, "rnano"),
+                ]),
+            ),
+            pkg(
+                "helix",
+                "A post-modern text editor",
+                BTreeSet::from([provider(package_name, "helix"), provider(binary, "hx")]),
+            ),
+            pkg(
+                "bash",
+                "GNU Bourne-Again Shell",
+                BTreeSet::from([provider(package_name, "bash"), provider(binary, "bash")]),
+            ),
+            pkg(
+                "zsh",
+                "Extensible shell designed for interactive use",
+                BTreeSet::from([provider(package_name, "zsh"), provider(binary, "zsh")]),
+            ),
+            pkg(
+                "fish",
+                "The friendly interactive shell",
+                BTreeSet::from([provider(package_name, "fish"), provider(binary, "fish")]),
+            ),
+        ];
+
+        registry.add_plugin(plugin::Plugin::Test(plugin::Test::new(1, packages)));
+        registry
+    }
+
+    struct TestFixture {
+        _root: tempfile::TempDir,
+        client: Client,
+    }
+
+    static TEST_FIXTURE: LazyLock<TestFixture> = LazyLock::new(|| {
+        let root = tempfile::tempdir().unwrap();
+        let installation = Installation::open(root.path(), None).unwrap();
+        let registry = test_registry();
+        let client = Client::mocked(installation, registry).unwrap();
+        TestFixture { _root: root, client }
     });
 
-    macro_rules! test_client {
-        () => {
-            match TEST_CLIENT.as_ref() {
-                Some(client) => client,
-                None => {
-                    eprintln!("Test Skipped: aosroot directory unavailable");
-                    return;
-                }
-            }
-        };
+    fn client() -> &'static Client {
+        &TEST_FIXTURE.client
+    }
+
+    fn flags_available() -> package::Flags {
+        package::Flags::default().with_available()
+    }
+
+    fn collect_result_names(results: &BTreeMap<MatchKind, Vec<Output>>) -> Vec<String> {
+        results
+            .values()
+            .flat_map(|outputs| outputs.iter().map(|output| output.name.as_str().to_owned()))
+            .collect()
+    }
+
+    fn names_for(results: &BTreeMap<MatchKind, Vec<Output>>, kind: &MatchKind) -> Vec<String> {
+        results
+            .get(kind)
+            .map(|outputs| outputs.iter().map(|o| o.name.as_str().to_owned()).collect())
+            .unwrap_or_default()
+    }
+
+    fn moss(args: &str) -> ArgMatches {
+        command().get_matches_from(args.split_whitespace())
+    }
+
+    fn test_handle(query: &str) -> BTreeMap<MatchKind, Vec<Output>> {
+        let args = moss(query);
+        let provider = determine_provider(&args).unwrap();
+        query_packages(client(), flags_available(), provider)
     }
 
     #[test]
-    fn test_find_packages() {
-        let client = test_client!();
-        let flags = package::Flags::new().with_available();
-        let output = search_packages(client, flags, "jq").unwrap();
-        assert!(!output.is_empty(), "expected match for package jq");
+    fn test_keyword_exact_name() {
+        let output = test_handle("search jq");
+        let names = collect_result_names(&output);
+        assert_eq!(names, vec!["jq"]);
     }
 
     #[test]
-    fn test_find_binaries_with_provides_flag() {
-        let client = test_client!();
-        let flags = package::Flags::new().with_available();
-        for binary_name in ["telnet", "toast", "zramctl"] {
-            // These binary names don't appear when searching by package name
-            let output = search_packages(client, flags, binary_name).unwrap();
-            assert!(
-                output.is_empty(),
-                "`search {binary_name}` output is not empty: {output:?}"
-            );
-
-            // We can find hits for all these binaries with the `--provides` flag
-            let output = provides_package(client, flags, "binaries", binary_name).unwrap();
-            assert!(
-                !output.is_empty(),
-                "`search --provides {binary_name} should not be empty"
-            );
+    fn test_keyword_shell_matches_case_insensitively() {
+        // Keyword search is case-insensitive so all three casings return the same results
+        for keyword in ["shell", "Shell", "SHELL"] {
+            let output = test_handle(&format!("search {keyword}"));
+            let names = collect_result_names(&output);
+            assert_eq!(names, vec!["bash", "fish", "zsh"]);
         }
     }
 
     #[test]
-    fn test_find_binaries_with_provider_syntax() {
-        let client = test_client!();
-        let flags = package::Flags::new().with_available();
-        for binary_name in ["telnet", "toast"] {
-            // These binary names don't appear when searching by package name
-            let output = search_packages(client, flags, binary_name).unwrap();
-            assert!(
-                output.is_empty(),
-                "`search {binary_name}` output is not empty: {output:?}"
-            );
+    fn test_keyword_summary_match() {
+        // "json" appears in jq's summary but not its name
+        let output = test_handle("search json");
+        let names = collect_result_names(&output);
+        assert_eq!(names, vec!["jq"]);
+    }
 
-            // We can find hits for all these binaries with the provider syntax
-            let provider_syntax = format!("binary({binary_name})");
-            let output = search_packages(client, flags, &provider_syntax).unwrap();
-            assert!(
-                !output.is_empty(),
-                "`search {provider_syntax}` output should not be empty"
-            );
+    #[test]
+    fn test_keyword_text_matches_multiple() {
+        // "text" matches:
+        //   helix ("text editor")
+        //   nano ("GNU Text Editor")
+        //   ripgrep ("text search")
+        let output = test_handle("search text");
+        let names = collect_result_names(&output);
+        assert_eq!(names, vec!["helix", "nano", "ripgrep"]);
+    }
+
+    /// TODO: `moss search` could eventually provide results on binary names by default
+    #[test]
+    fn test_keyword_binary_name_returns_nothing() {
+        for query in ["search hx", "search rg"] {
+            let output = test_handle(query);
+            assert!(output.values().all(Vec::is_empty));
         }
     }
 
     #[test]
-    fn test_provider_syntax_produces_same_output_as_provides_flag() {
-        let client = test_client!();
-        let flags = package::Flags::new().with_available();
-        for binary_name in ["hx", "telnet", "toast"] {
-            let output_a = provides_package(client, flags, "binaries", binary_name).unwrap();
-            let provider_syntax = format!("binary({binary_name})");
-            let output_b = search_packages(client, flags, &provider_syntax).unwrap();
-            assert_eq!(output_a, output_b);
-        }
+    fn test_keyword_nonexistent_returns_nothing() {
+        let output = test_handle("search no-such-package");
+        assert!(output.values().all(Vec::is_empty));
+    }
+
+    #[test]
+    fn test_keyword_uppercase_matches_case_insensitively() {
+        let output = test_handle("search NANO");
+        let names = collect_result_names(&output);
+        assert_eq!(names, vec!["nano"]);
+    }
+
+    #[test]
+    fn test_provider_binary_hx_finds_helix() {
+        let output_provides_flag = test_handle("search --provides=binary hx");
+        let output_dependency_syntax = test_handle("search binary(hx)");
+
+        let names_provides_flag = collect_result_names(&output_provides_flag);
+        let names_dependency_syntax = collect_result_names(&output_dependency_syntax);
+
+        assert_eq!(names_provides_flag, names_dependency_syntax);
+        assert_eq!(names_provides_flag, vec!["helix"]);
+    }
+
+    #[test]
+    fn test_provider_binary_rg_finds_ripgrep() {
+        let output_provides_flag = test_handle("search --provides=binary rg");
+        let output_dependency_syntax = test_handle("search binary(rg)");
+
+        let names_provides_flag = collect_result_names(&output_provides_flag);
+        let names_dependency_syntax = collect_result_names(&output_dependency_syntax);
+
+        assert_eq!(names_provides_flag, names_dependency_syntax);
+        assert_eq!(names_provides_flag, vec!["ripgrep"]);
+    }
+
+    #[test]
+    fn test_provider_binary_jq_finds_jq() {
+        let output_provides_flag = test_handle("search --provides=binary jq");
+        let output_dependency_syntax = test_handle("search binary(jq)");
+
+        let names_provides_flag = collect_result_names(&output_provides_flag);
+        let names_dependency_syntax = collect_result_names(&output_dependency_syntax);
+
+        assert_eq!(names_provides_flag, names_dependency_syntax);
+        assert_eq!(names_provides_flag, vec!["jq"]);
     }
 }

--- a/moss/src/cli/search.rs
+++ b/moss/src/cli/search.rs
@@ -71,32 +71,39 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
 }
 
 fn search_packages(client: Client, flags: package::Flags, keyword: &str) -> Vec<Output> {
-    client
-        .search_packages(keyword, flags)
-        .map(|pkg| Output {
-            name: pkg.meta.name,
-            summary: pkg.meta.summary,
-        })
-        .collect()
+    client.search_packages(keyword, flags).map(Output::from).collect()
+}
+
+fn search_providing_packages_by_kind(
+    client: &Client,
+    flags: package::Flags,
+    name: &str,
+    kind: dependency::Kind,
+) -> Vec<package::Package> {
+    let provider = Provider {
+        kind,
+        name: name.to_owned(),
+    };
+    client.lookup_packages_by_provider(&provider, flags)
 }
 
 fn search_providing_packages(client: Client, flags: package::Flags, name: &str) -> Vec<Output> {
     // We need to search both Binary and SystemBinary for possible programs
     // TODO: Could include shared libraries down the line, maybe with a flag
-    [dependency::Kind::Binary, dependency::Kind::SystemBinary]
-        .into_iter()
-        .flat_map(|kind| {
-            let provider = Provider {
-                kind,
-                name: name.to_owned(),
-            };
-            client.lookup_packages_by_provider(&provider, flags)
-        })
-        .map(|pkg| Output {
-            name: pkg.meta.name,
-            summary: pkg.meta.summary,
-        })
-        .collect()
+    if name.contains('(') {
+        let provider = Provider::from_name(name).expect("Invalid provider format");
+        client
+            .lookup_packages_by_provider(&provider, flags)
+            .into_iter()
+            .map(Output::from)
+            .collect()
+    } else {
+        [dependency::Kind::Binary, dependency::Kind::SystemBinary]
+            .into_iter()
+            .flat_map(|kind| search_providing_packages_by_kind(&client, flags, name, kind))
+            .map(Output::from)
+            .collect()
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -123,5 +130,14 @@ impl ColumnDisplay for Output {
             " ".repeat(width),
             self.summary
         );
+    }
+}
+
+impl From<package::Package> for Output {
+    fn from(pkg: package::Package) -> Self {
+        Output {
+            name: pkg.meta.name,
+            summary: pkg.meta.summary,
+        }
     }
 }

--- a/moss/src/cli/search.rs
+++ b/moss/src/cli/search.rs
@@ -111,16 +111,15 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
         package::Flags::new().with_available()
     };
 
-    let mut output = query_packages(&client, flags, provider);
+    let output = query_packages(&client, flags, provider);
 
     if output.values().all(Vec::is_empty) {
         return Ok(());
     }
 
-    for (match_kind, value) in output.iter_mut() {
-        println!("Matched field: {match_kind}");
+    for mut value in output.into_values() {
         value.sort();
-        print_columns(value, 1);
+        print_columns(&value, 1);
     }
 
     Ok(())
@@ -188,7 +187,7 @@ impl ColumnDisplay for Output {
             let (summary_prefix, summary_matched, summary_suffix) = highlight_string(&self.summary, expression);
             let _ = write!(
                 writer,
-                " {}{}{}{:width$}  {}{}{}",
+                "{}{}{}{:width$}  {}{}{}",
                 name_prefix.bold(),
                 name_matched.bold().green(),
                 name_suffix.bold(),
@@ -200,7 +199,7 @@ impl ColumnDisplay for Output {
         } else {
             let _ = write!(
                 writer,
-                " {}{:width$}  {}",
+                "{}{:width$}  {}",
                 self.name.as_str().bold(),
                 " ".repeat(width),
                 self.summary

--- a/moss/src/cli/search.rs
+++ b/moss/src/cli/search.rs
@@ -76,7 +76,11 @@ fn search_packages(client: &Client, flags: package::Flags, keyword: &str) -> Vec
     match provider.kind {
         dependency::Kind::PackageName => client
             .search_packages(&provider.name, flags)
-            .map(Output::from)
+            .map(|pkg| Output {
+                name: pkg.meta.name,
+                summary: pkg.meta.summary,
+                search_match: Some(keyword.to_owned()),
+            })
             .collect(),
         _ => client
             .lookup_packages_by_provider(&provider, flags)
@@ -119,21 +123,47 @@ pub enum Error {
 struct Output {
     name: Name,
     summary: String,
+    search_match: Option<String>,
 }
 
+fn highlight_string(content: &str, expression: &str) -> (String, String, String) {
+    if let Some(index) = content.find(expression) {
+        let (prefix, body) = content.split_at(index);
+        let (matched, suffix) = body.split_at(expression.len());
+        (prefix.to_owned(), matched.to_owned(), suffix.to_owned())
+    } else {
+        (content.to_owned(), String::default(), String::default())
+    }
+}
 impl ColumnDisplay for Output {
     fn get_display_width(&self) -> usize {
         self.name.as_str().chars().count()
     }
 
     fn display_column(&self, writer: &mut impl std::io::prelude::Write, _col: tui::pretty::Column, width: usize) {
-        let _ = write!(
-            writer,
-            "{}{:width$}  {}",
-            self.name.as_str().bold(),
-            " ".repeat(width),
-            self.summary
-        );
+        if let Some(expression) = self.search_match.clone() {
+            let (name_prefix, name_matched, name_suffix) = highlight_string(self.name.as_str(), &expression);
+            let (summary_prefix, summary_matched, summary_suffix) = highlight_string(&self.summary, &expression);
+            let _ = write!(
+                writer,
+                " {}{}{}{:width$}  {}{}{}",
+                name_prefix.bold(),
+                name_matched.bold().green(),
+                name_suffix.bold(),
+                " ".repeat(width),
+                summary_prefix.bold(),
+                summary_matched.bold().green(),
+                summary_suffix.bold(),
+            );
+        } else {
+            let _ = write!(
+                writer,
+                " {}{:width$}  {}",
+                self.name.as_str().bold(),
+                " ".repeat(width),
+                self.summary
+            );
+        }
     }
 }
 
@@ -142,6 +172,7 @@ impl From<package::Package> for Output {
         Output {
             name: pkg.meta.name,
             summary: pkg.meta.summary,
+            search_match: None,
         }
     }
 }

--- a/moss/src/cli/search.rs
+++ b/moss/src/cli/search.rs
@@ -56,9 +56,9 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
     };
 
     let output = if provides {
-        search_providing_packages(client, flags, keyword)
+        provides_package(&client, flags, keyword)
     } else {
-        search_packages(client, flags, keyword)
+        search_packages(&client, flags, keyword)
     };
 
     if output.is_empty() {
@@ -70,8 +70,20 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
     Ok(())
 }
 
-fn search_packages(client: Client, flags: package::Flags, keyword: &str) -> Vec<Output> {
-    client.search_packages(keyword, flags).map(Output::from).collect()
+fn search_packages(client: &Client, flags: package::Flags, keyword: &str) -> Vec<Output> {
+    let provider = Provider::from_name(keyword).expect("Invalid format");
+
+    match provider.kind {
+        dependency::Kind::PackageName => client
+            .search_packages(&provider.name, flags)
+            .map(Output::from)
+            .collect(),
+        _ => client
+            .lookup_packages_by_provider(&provider, flags)
+            .into_iter()
+            .map(Output::from)
+            .collect(),
+    }
 }
 
 fn search_providing_packages_by_kind(
@@ -87,23 +99,14 @@ fn search_providing_packages_by_kind(
     client.lookup_packages_by_provider(&provider, flags)
 }
 
-fn search_providing_packages(client: Client, flags: package::Flags, name: &str) -> Vec<Output> {
+fn provides_package(client: &Client, flags: package::Flags, name: &str) -> Vec<Output> {
     // We need to search both Binary and SystemBinary for possible programs
     // TODO: Could include shared libraries down the line, maybe with a flag
-    if name.contains('(') {
-        let provider = Provider::from_name(name).expect("Invalid provider format");
-        client
-            .lookup_packages_by_provider(&provider, flags)
-            .into_iter()
-            .map(Output::from)
-            .collect()
-    } else {
-        [dependency::Kind::Binary, dependency::Kind::SystemBinary]
-            .into_iter()
-            .flat_map(|kind| search_providing_packages_by_kind(&client, flags, name, kind))
-            .map(Output::from)
-            .collect()
-    }
+    [dependency::Kind::Binary, dependency::Kind::SystemBinary]
+        .into_iter()
+        .flat_map(|kind| search_providing_packages_by_kind(client, flags, name, kind))
+        .map(Output::from)
+        .collect()
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -112,6 +115,7 @@ pub enum Error {
     Client(#[from] client::Error),
 }
 
+#[cfg_attr(test, derive(Debug, PartialEq))] // Only derive these traits in test suite
 struct Output {
     name: Name,
     summary: String,
@@ -138,6 +142,71 @@ impl From<package::Package> for Output {
         Output {
             name: pkg.meta.name,
             summary: pkg.meta.summary,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    use std::sync::LazyLock;
+
+    use super::*;
+
+    static TEST_CLIENT: LazyLock<Client> = LazyLock::new(|| {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../aosroot");
+        let installation = Installation::open(root, None).expect("Could not find root");
+        Client::new("TEST", installation).expect("Could not set up client")
+    });
+
+    #[test]
+    fn test_find_packages() {
+        let client = &TEST_CLIENT;
+        let flags = package::Flags::new().with_available();
+        let output = search_packages(client, flags, "jq");
+        assert!(!output.is_empty(), "expected match for package jq");
+    }
+
+    #[test]
+    fn test_find_binaries_with_provides_flag() {
+        let client = &TEST_CLIENT;
+        let flags = package::Flags::new().with_available();
+        for binary_name in ["hx", "telnet", "toast", "zramctl"] {
+            // These binary names don't appear when searching by package name
+            let output = search_packages(client, flags, binary_name);
+            assert!(output.is_empty());
+
+            // We can find hits for all these binaries with the `--provides` flag
+            let output = provides_package(client, flags, binary_name);
+            assert!(!output.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_find_binaries_with_provider_syntax() {
+        let client = &TEST_CLIENT;
+        let flags = package::Flags::new().with_available();
+        for binary_name in ["hx", "telnet", "toast"] {
+            // These binary names don't appear when searching by package name
+            let output = search_packages(client, flags, binary_name);
+            assert!(output.is_empty());
+
+            // We can find hits for all these binaries with the provider syntax
+            let provider_syntax = format!("binary({binary_name})");
+            let output = search_packages(client, flags, &provider_syntax);
+            assert!(!output.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_provider_syntax_produces_same_output_as_provides_flag() {
+        let client = &TEST_CLIENT;
+        let flags = package::Flags::new().with_available();
+        for binary_name in ["hx", "telnet", "toast"] {
+            let output_a = provides_package(client, flags, binary_name);
+            let provider_syntax = format!("binary({binary_name})");
+            let output_b = search_packages(client, flags, &provider_syntax);
+            assert_eq!(output_a, output_b);
         }
     }
 }

--- a/moss/src/cli/search.rs
+++ b/moss/src/cli/search.rs
@@ -184,15 +184,27 @@ mod tests {
 
     use super::*;
 
-    static TEST_CLIENT: LazyLock<Client> = LazyLock::new(|| {
+    static TEST_CLIENT: LazyLock<Option<Client>> = LazyLock::new(|| {
         let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../aosroot");
-        let installation = Installation::open(root, None).expect("Could not find root");
-        Client::new("TEST", installation).expect("Could not set up client")
+        let installation = Installation::open(root, None).ok()?;
+        Client::new("TEST", installation).ok()
     });
+
+    macro_rules! test_client {
+        () => {
+            match TEST_CLIENT.as_ref() {
+                Some(client) => client,
+                None => {
+                    eprintln!("Test Skipped: aosroot directory unavailable");
+                    return;
+                }
+            }
+        };
+    }
 
     #[test]
     fn test_find_packages() {
-        let client = &TEST_CLIENT;
+        let client = test_client!();
         let flags = package::Flags::new().with_available();
         let output = search_packages(client, flags, "jq");
         assert!(!output.is_empty(), "expected match for package jq");
@@ -200,38 +212,50 @@ mod tests {
 
     #[test]
     fn test_find_binaries_with_provides_flag() {
-        let client = &TEST_CLIENT;
+        let client = test_client!();
         let flags = package::Flags::new().with_available();
-        for binary_name in ["hx", "telnet", "toast", "zramctl"] {
+        for binary_name in ["telnet", "toast", "zramctl"] {
             // These binary names don't appear when searching by package name
             let output = search_packages(client, flags, binary_name);
-            assert!(output.is_empty());
+            assert!(
+                output.is_empty(),
+                "`search {binary_name}` output is not empty: {output:?}"
+            );
 
             // We can find hits for all these binaries with the `--provides` flag
             let output = provides_package(client, flags, binary_name);
-            assert!(!output.is_empty());
+            assert!(
+                !output.is_empty(),
+                "`search --provides {binary_name} should not be empty"
+            );
         }
     }
 
     #[test]
     fn test_find_binaries_with_provider_syntax() {
-        let client = &TEST_CLIENT;
+        let client = test_client!();
         let flags = package::Flags::new().with_available();
-        for binary_name in ["hx", "telnet", "toast"] {
+        for binary_name in ["telnet", "toast"] {
             // These binary names don't appear when searching by package name
             let output = search_packages(client, flags, binary_name);
-            assert!(output.is_empty());
+            assert!(
+                output.is_empty(),
+                "`search {binary_name}` output is not empty: {output:?}"
+            );
 
             // We can find hits for all these binaries with the provider syntax
             let provider_syntax = format!("binary({binary_name})");
             let output = search_packages(client, flags, &provider_syntax);
-            assert!(!output.is_empty());
+            assert!(
+                !output.is_empty(),
+                "`search {provider_syntax}` output should not be empty"
+            );
         }
     }
 
     #[test]
     fn test_provider_syntax_produces_same_output_as_provides_flag() {
-        let client = &TEST_CLIENT;
+        let client = test_client!();
         let flags = package::Flags::new().with_available();
         for binary_name in ["hx", "telnet", "toast"] {
             let output_a = provides_package(client, flags, binary_name);

--- a/moss/src/cli/search.rs
+++ b/moss/src/cli/search.rs
@@ -74,19 +74,35 @@ fn map_aliases(value: &str) -> &str {
     }
 }
 
-pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error> {
+fn determine_provider(args: &ArgMatches) -> Result<Provider, Error> {
     let keyword = args.get_one::<String>(ARG_KEYWORD).unwrap();
-    let only_installed = args.get_flag(FLAG_INSTALLED);
-    let provider_kind = args
+    let provides_flag = args
         .get_one::<String>(FLAG_PROVIDES)
         .map(|s| map_aliases(s))
         .map(|s| s.parse::<dependency::Kind>().expect("clap should restrict input"));
-    let provider = Provider::from_name(keyword)
-        .map_err(|_| Error::ParseError(keyword.to_owned()))
-        .map(|provider| Provider {
-            kind: provider_kind.unwrap_or(provider.kind),
-            ..provider
-        })?;
+    if let Some(kind) = provides_flag {
+        Ok(Provider {
+            kind,
+            name: keyword.to_owned(),
+        })
+    } else {
+        Provider::from_name(keyword).map_err(|_| Error::ParseError(keyword.to_owned()))
+    }
+}
+
+fn query_packages(client: &Client, flags: package::Flags, provider: Provider) -> BTreeMap<MatchKind, Vec<Output>> {
+    match provider {
+        Provider {
+            kind: dependency::Kind::PackageName,
+            name,
+        } => search_packages(client, flags, &name),
+        _ => search_by_provider(client, flags, provider),
+    }
+}
+
+pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error> {
+    let only_installed = args.get_flag(FLAG_INSTALLED);
+    let provider = determine_provider(args)?;
 
     let client = Client::new(environment::NAME, installation)?;
     let flags = if only_installed {
@@ -95,18 +111,9 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
         package::Flags::new().with_available()
     };
 
-    let mut output = match provider {
-        Provider {
-            kind: dependency::Kind::PackageName,
-            name: _name,
-        } => search_packages(&client, flags, keyword),
-        Provider {
-            kind: _kind,
-            name: ref _name,
-        } => provides_package(&client, flags, provider),
-    }?;
+    let mut output = query_packages(&client, flags, provider);
 
-    if output.values().all(|pkgs| pkgs.is_empty()) {
+    if output.values().all(Vec::is_empty) {
         return Ok(());
     }
 
@@ -119,38 +126,29 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
     Ok(())
 }
 
-fn search_packages(
-    client: &Client,
-    flags: package::Flags,
-    keyword: &str,
-) -> Result<BTreeMap<MatchKind, Vec<Output>>, Error> {
-    let mut output_kind: BTreeMap<MatchKind, Vec<Output>> = BTreeMap::new();
+fn search_packages(client: &Client, flags: package::Flags, keyword: &str) -> BTreeMap<MatchKind, Vec<Output>> {
+    let mut results: BTreeMap<MatchKind, Vec<Output>> = BTreeMap::new();
 
+    let keyword_lowercase = keyword.to_ascii_lowercase();
     for pkg in client.search_packages(keyword, flags) {
         let pkg_name_lowercase = pkg.meta.name.as_str().to_ascii_lowercase();
-        let match_kind = if pkg_name_lowercase.contains(&keyword.to_ascii_lowercase()) {
+        let match_kind = if pkg_name_lowercase.contains(&keyword_lowercase) {
             MatchKind::Name
         } else {
             MatchKind::Summary
         };
-        output_kind.entry(match_kind).or_default().push(Output {
+        results.entry(match_kind).or_default().push(Output {
             name: pkg.meta.name,
             summary: pkg.meta.summary,
             search_match: Some(keyword.to_owned()),
         });
     }
-    Ok(output_kind)
+    results
 }
 
-fn provides_package(
-    client: &Client,
-    flags: package::Flags,
-    provider: Provider,
-) -> Result<BTreeMap<MatchKind, Vec<Output>>, Error> {
-    let mut result: BTreeMap<MatchKind, Vec<Output>> = BTreeMap::new();
+fn search_by_provider(client: &Client, flags: package::Flags, provider: Provider) -> BTreeMap<MatchKind, Vec<Output>> {
     let packages = client.lookup_packages_by_provider(&provider, flags);
-    result.insert(MatchKind::Name, packages.into_iter().map(Output::from).collect());
-    Ok(result)
+    BTreeMap::from([(MatchKind::Name, packages.into_iter().map(Output::from).collect())])
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -232,7 +230,9 @@ mod tests {
 
     use super::*;
 
-    fn pkg(name: &str, summary: &str, providers: BTreeSet<Provider>) -> Package {
+    fn pkg(name: &str, summary: &str, providers: &[Provider]) -> Package {
+        let mut providers: BTreeSet<Provider> = providers.iter().cloned().collect();
+        providers.insert(provider(dependency::Kind::PackageName, name));
         Package {
             id: package::Id::from(name.to_owned()),
             meta: package::Meta {
@@ -269,58 +269,35 @@ mod tests {
     /// and manifest.x86_64.jsonc files in the recipes repository.
     fn test_registry() -> Registry {
         let mut registry = Registry::default();
-        let package_name = dependency::Kind::PackageName;
         let binary = dependency::Kind::Binary;
+        let soname = dependency::Kind::SharedLibrary;
+        let pkgconfig = dependency::Kind::PkgConfig;
 
         let packages = vec![
-            pkg(
-                "git",
-                "Fast, scalable, distributed revision control system",
-                BTreeSet::from([provider(package_name, "git"), provider(binary, "git")]),
-            ),
-            pkg(
-                "jq",
-                "Command-line JSON processor",
-                BTreeSet::from([provider(package_name, "jq"), provider(binary, "jq")]),
-            ),
-            pkg(
-                "ripgrep",
-                "Recursive text search utility",
-                BTreeSet::from([provider(package_name, "ripgrep"), provider(binary, "rg")]),
-            ),
-            pkg(
-                "fd",
-                "A simple, fast and user-friendly alternative to find",
-                BTreeSet::from([provider(package_name, "fd"), provider(binary, "fd")]),
-            ),
+            pkg("jq", "Command-line JSON processor", &[provider(binary, "jq")]),
+            pkg("ripgrep", "Recursive text search utility", &[provider(binary, "rg")]),
             pkg(
                 "nano",
                 "GNU Text Editor",
-                BTreeSet::from([
-                    provider(package_name, "nano"),
-                    provider(binary, "nano"),
-                    provider(binary, "rnano"),
-                ]),
+                &[provider(binary, "nano"), provider(binary, "rnano")],
             ),
-            pkg(
-                "helix",
-                "A post-modern text editor",
-                BTreeSet::from([provider(package_name, "helix"), provider(binary, "hx")]),
-            ),
-            pkg(
-                "bash",
-                "GNU Bourne-Again Shell",
-                BTreeSet::from([provider(package_name, "bash"), provider(binary, "bash")]),
-            ),
+            pkg("helix", "A post-modern text editor", &[provider(binary, "hx")]),
+            pkg("bash", "GNU Bourne-Again Shell", &[provider(binary, "bash")]),
             pkg(
                 "zsh",
                 "Extensible shell designed for interactive use",
-                BTreeSet::from([provider(package_name, "zsh"), provider(binary, "zsh")]),
+                &[provider(binary, "zsh")],
+            ),
+            pkg("fish", "The friendly interactive shell", &[provider(binary, "fish")]),
+            pkg(
+                "libyaml",
+                "YAML 1.1 library",
+                &[provider(soname, "libyaml-0.so.2(x86_64)")],
             ),
             pkg(
-                "fish",
-                "The friendly interactive shell",
-                BTreeSet::from([provider(package_name, "fish"), provider(binary, "fish")]),
+                "libyaml-devel",
+                "Development files for libyaml",
+                &[provider(pkgconfig, "yaml-0.1")],
             ),
         ];
 
@@ -350,23 +327,19 @@ mod tests {
     }
 
     fn collect_result_names(results: &BTreeMap<MatchKind, Vec<Output>>) -> Vec<String> {
-        results
+        let mut names: Vec<String> = results
             .values()
             .flat_map(|outputs| outputs.iter().map(|output| output.name.as_str().to_owned()))
-            .collect()
-    }
-
-    fn names_for(results: &BTreeMap<MatchKind, Vec<Output>>, kind: &MatchKind) -> Vec<String> {
-        results
-            .get(kind)
-            .map(|outputs| outputs.iter().map(|o| o.name.as_str().to_owned()).collect())
-            .unwrap_or_default()
+            .collect();
+        names.sort();
+        names
     }
 
     fn moss(args: &str) -> ArgMatches {
         command().get_matches_from(args.split_whitespace())
     }
 
+    /// Test helper function that approximates the behavior of `handle()`
     fn test_handle(query: &str) -> BTreeMap<MatchKind, Vec<Output>> {
         let args = moss(query);
         let provider = determine_provider(&args).unwrap();
@@ -465,5 +438,29 @@ mod tests {
 
         assert_eq!(names_provides_flag, names_dependency_syntax);
         assert_eq!(names_provides_flag, vec!["jq"]);
+    }
+
+    #[test]
+    fn test_provider_soname_finds_libyaml() {
+        let output_provides_flag = test_handle("search --provides=soname libyaml-0.so.2(x86_64)");
+        let output_dependency_syntax = test_handle("search soname(libyaml-0.so.2(x86_64))");
+
+        let names_provides_flag = collect_result_names(&output_provides_flag);
+        let names_dependency_syntax = collect_result_names(&output_dependency_syntax);
+
+        assert_eq!(names_provides_flag, names_dependency_syntax);
+        assert_eq!(names_provides_flag, vec!["libyaml"]);
+    }
+
+    #[test]
+    fn test_provider_pkgconfig_finds_libyaml_devel() {
+        let output_provides_flag = test_handle("search --provides=pkgconfig yaml-0.1");
+        let output_dependency_syntax = test_handle("search pkgconfig(yaml-0.1)");
+
+        let names_provides_flag = collect_result_names(&output_provides_flag);
+        let names_dependency_syntax = collect_result_names(&output_dependency_syntax);
+
+        assert_eq!(names_provides_flag, names_dependency_syntax);
+        assert_eq!(names_provides_flag, vec!["libyaml-devel"]);
     }
 }

--- a/moss/src/client/mod.rs
+++ b/moss/src/client/mod.rs
@@ -881,6 +881,27 @@ impl Client {
     pub fn list_layouts(&self) -> Result<Vec<(package::Id, StonePayloadLayoutRecord)>, Error> {
         self.layout_db.all().map_err(Error::Db)
     }
+
+    #[cfg(any(test, feature = "testing"))]
+    pub fn mocked(installation: Installation, registry: Registry) -> Result<Client, Error> {
+        let config = config::Manager::system(&installation.root, "moss");
+        let install_db = db::meta::Database::new(":memory:")?;
+        let state_db = db::state::Database::new(":memory:")?;
+        let layout_db = db::layout::Database::new(":memory:")?;
+
+        let repositories = repository::Manager::system(config.clone(), installation.clone())?;
+
+        Ok(Client {
+            config,
+            installation,
+            repositories,
+            registry,
+            install_db,
+            state_db,
+            layout_db,
+            scope: Scope::Stateful,
+        })
+    }
 }
 
 /// Add root symlinks & os-release file

--- a/moss/src/registry/plugin/mod.rs
+++ b/moss/src/registry/plugin/mod.rs
@@ -15,7 +15,7 @@ use crate::registry::package::{self, Package};
 pub use self::active::Active;
 pub use self::cobble::Cobble;
 pub use self::repository::Repository;
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 pub use self::test::Test;
 
 mod active;
@@ -31,7 +31,7 @@ pub enum Plugin {
     Cobble(Cobble),
     Repository(Repository),
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "testing"))]
     Test(Test),
 }
 
@@ -44,7 +44,7 @@ impl Plugin {
             Plugin::Cobble(plugin) => plugin.package(id),
             Plugin::Repository(plugin) => plugin.package(id),
 
-            #[cfg(test)]
+            #[cfg(any(test, feature = "testing"))]
             Plugin::Test(plugin) => plugin.package(id),
         }
     }
@@ -56,7 +56,7 @@ impl Plugin {
             Plugin::Cobble(plugin) => plugin.list(flags),
             Plugin::Repository(plugin) => plugin.list(flags),
 
-            #[cfg(test)]
+            #[cfg(any(test, feature = "testing"))]
             Plugin::Test(plugin) => plugin.list(flags),
         })
     }
@@ -67,7 +67,7 @@ impl Plugin {
             Plugin::Cobble(plugin) => plugin.query_keyword(keyword, flags),
             Plugin::Repository(plugin) => plugin.query_keyword(keyword, flags),
 
-            #[cfg(test)]
+            #[cfg(any(test, feature = "testing"))]
             Plugin::Test(plugin) => plugin.query_keyword(keyword, flags),
         })
     }
@@ -79,7 +79,7 @@ impl Plugin {
             Plugin::Cobble(plugin) => plugin.query_provider(provider, flags),
             Plugin::Repository(plugin) => plugin.query_provider(provider, flags),
 
-            #[cfg(test)]
+            #[cfg(any(test, feature = "testing"))]
             Plugin::Test(plugin) => plugin.query_provider(provider, flags),
         })
     }
@@ -98,7 +98,7 @@ impl Plugin {
                 .collect(),
             Plugin::Repository(plugin) => plugin.query_provider_id_only(provider, flags),
 
-            #[cfg(test)]
+            #[cfg(any(test, feature = "testing"))]
             Plugin::Test(plugin) => plugin.query_provider_id_only(provider, flags),
         })
     }
@@ -110,7 +110,7 @@ impl Plugin {
             Plugin::Cobble(plugin) => plugin.query_name(package_name, flags),
             Plugin::Repository(plugin) => plugin.query_name(package_name, flags),
 
-            #[cfg(test)]
+            #[cfg(any(test, feature = "testing"))]
             Plugin::Test(plugin) => plugin.query_name(package_name, flags),
         })
     }
@@ -124,13 +124,13 @@ impl Plugin {
             Plugin::Cobble(plugin) => plugin.priority(),
             Plugin::Repository(plugin) => plugin.priority(),
 
-            #[cfg(test)]
+            #[cfg(any(test, feature = "testing"))]
             Plugin::Test(plugin) => plugin.priority,
         }
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 pub mod test {
     use super::*;
 
@@ -158,9 +158,13 @@ pub mod test {
         }
 
         pub fn query_keyword(&self, keyword: &str, _flags: package::Flags) -> Vec<Package> {
+            let keyword_lower = keyword.to_ascii_lowercase();
             self.packages
                 .iter()
-                .filter(|pkg| pkg.meta.name.contains(keyword) || pkg.meta.summary.contains(keyword))
+                .filter(|pkg| {
+                    pkg.meta.name.as_str().to_ascii_lowercase().contains(&keyword_lower)
+                        || pkg.meta.summary.to_ascii_lowercase().contains(&keyword_lower)
+                })
                 .cloned()
                 .collect()
         }


### PR DESCRIPTION
I've worked on some of the suggestions from https://github.com/AerynOS/os-tools/issues/729 plus a few improvements to search:

* `moss search` supports searching on the provider syntax, ie `moss search 'sysbinary(zramctl)'`
* `moss search` groups matches based on matches in package name or package summary
* `moss search` highlights matched substrings in package name or package summary

<img width="1831" height="626" alt="Screenshot_20260329_232406" src="https://github.com/user-attachments/assets/ac68c01d-f480-48c5-a8a3-317685b20474" />

Changes not yet implemented include grouping matches based on provider type and searching based on file path. 