### PR TITLE
Introduce the gitwrap crate and refactor how we deal with Upstreams in Boulder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,6 +1227,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "gitwrap"
+version = "0.26.1"
+dependencies = [
+ "thiserror",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,7 @@ dependencies = [
  "filetime",
  "fs-err",
  "futures-util",
+ "gitwrap",
  "glob",
  "hex",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,11 @@ thread-priority = "3.0.0"
 tokio = { version = "1.38.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io"] }
 tracing = { version = "0.1.41", features = ["attributes"] }
-tracing-subscriber = { version = "0.3.19", default-features = false, features = ["ansi", "fmt", "json"] }
+tracing-subscriber = { version = "0.3.19", default-features = false, features = [
+    "ansi",
+    "fmt",
+    "json",
+] }
 triomphe = { version = "0.1.15", default-features = false }
 url = { version = "2.5.2", features = ["serde"] }
 xxhash-rust = { version = "0.8.11", features = ["xxh3"] }

--- a/boulder/Cargo.toml
+++ b/boulder/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 [dependencies]
 config = { path = "../crates/config" }
 container = { path = "../crates/container" }
+gitwrap = { path = "../crates/gitwrap" }
 moss = { path = "../moss" }
 tools_buildinfo = { path = "../crates/tools_buildinfo" }
 stone = { path = "../crates/stone" }

--- a/boulder/src/build.rs
+++ b/boulder/src/build.rs
@@ -120,7 +120,7 @@ impl Builder {
         timing: &mut Timing,
         initialize_timer: timing::Timer,
         update_repos: bool,
-    ) -> Result<Vec<upstream::Shared>, Error> {
+    ) -> Result<Vec<upstream::Stored>, Error> {
         // Recreate artifacts
         util::recreate_dir(&self.paths.artefacts().host).map_err(Error::RecreateArtefactsDir)?;
 
@@ -133,7 +133,8 @@ impl Builder {
         let timer = timing.begin(timing::Kind::Fetch);
 
         // Sync (fetch & share) upstreams to rootfs
-        let shared = upstream::sync(
+        let stored = upstream::sync(
+            &self.recipe,
             &self.upstreams,
             &self.paths.upstreams().host,
             &self.paths.guest_host_path(&self.paths.upstreams()),
@@ -141,7 +142,7 @@ impl Builder {
 
         timing.finish(timer);
 
-        Ok(shared)
+        Ok(stored)
     }
 
     pub fn cleanup(&self) -> Result<(), Error> {

--- a/boulder/src/build.rs
+++ b/boulder/src/build.rs
@@ -88,7 +88,7 @@ impl Builder {
             })
             .collect::<Result<Vec<_>, job::Error>>()?;
 
-        let upstreams = upstream::parse(&recipe)?;
+        let upstreams = upstream::parse_recipe(&recipe)?;
 
         let profiles = profile::Manager::new(&env);
         let repos = profiles.repositories(&profile)?.clone();
@@ -115,7 +115,12 @@ impl Builder {
         })
     }
 
-    pub fn setup(&self, timing: &mut Timing, initialize_timer: timing::Timer, update_repos: bool) -> Result<(), Error> {
+    pub fn setup(
+        &self,
+        timing: &mut Timing,
+        initialize_timer: timing::Timer,
+        update_repos: bool,
+    ) -> Result<Vec<upstream::Shared>, Error> {
         // Recreate artifacts
         util::recreate_dir(&self.paths.artefacts().host).map_err(Error::RecreateArtefactsDir)?;
 
@@ -128,11 +133,15 @@ impl Builder {
         let timer = timing.begin(timing::Kind::Fetch);
 
         // Sync (fetch & share) upstreams to rootfs
-        upstream::sync(&self.recipe, &self.paths, &self.upstreams)?;
+        let shared = upstream::sync(
+            &self.upstreams,
+            &self.paths.upstreams().host,
+            &self.paths.guest_host_path(&self.paths.upstreams()),
+        )?;
 
         timing.finish(timer);
 
-        Ok(())
+        Ok(shared)
     }
 
     pub fn cleanup(&self) -> Result<(), Error> {
@@ -150,7 +159,7 @@ impl Builder {
         }
 
         // Remove downloaded upstreams
-        upstream::remove(&self.paths, &self.upstreams)?;
+        upstream::remove(&self.paths.upstreams().host, &self.upstreams)?;
 
         // Prune moss cache, retaining stones from the repos defined
         // by our boulder profile

--- a/boulder/src/build/job.rs
+++ b/boulder/src/build/job.rs
@@ -71,21 +71,19 @@ fn work_dir(build_dir: &Path, upstreams: &[Upstream]) -> PathBuf {
         upstream::Props::Git { .. } => true,
     }) {
         match &upstream.props {
-            upstream::Props::Plain { rename, .. } => {
+            upstream::Props::Plain { rename, unpack_dir, .. } => {
                 let file_name = util::uri_file_name(&upstream.url);
                 let rename = rename.as_deref().unwrap_or(file_name);
-                let unpack_dir = upstream
-                    .unpack_dir
+                let unpack_dir = unpack_dir
                     .as_ref()
                     .map(|dir| dir.display().to_string())
                     .unwrap_or_else(|| rename.to_owned());
 
                 work_dir = build_dir.join(unpack_dir);
             }
-            upstream::Props::Git { .. } => {
+            upstream::Props::Git { clone_dir, .. } => {
                 let source = util::uri_file_name(&upstream.url);
-                let target = upstream
-                    .unpack_dir
+                let target = clone_dir
                     .as_ref()
                     .map(|dir| dir.display().to_string())
                     .unwrap_or_else(|| source.to_owned());

--- a/boulder/src/build/job/phase.rs
+++ b/boulder/src/build/job/phase.rs
@@ -244,6 +244,7 @@ fn prepare_script(upstreams: &[upstream::Upstream]) -> String {
                 rename,
                 strip_dirs,
                 unpack,
+                unpack_dir,
                 ..
             } => {
                 if !unpack {
@@ -251,8 +252,7 @@ fn prepare_script(upstreams: &[upstream::Upstream]) -> String {
                 }
                 let file_name = util::uri_file_name(&upstream.url);
                 let rename = rename.as_deref().unwrap_or(file_name);
-                let unpack_dir = upstream
-                    .unpack_dir
+                let unpack_dir = unpack_dir
                     .as_ref()
                     .map(|dir| dir.display().to_string())
                     .unwrap_or_else(|| rename.to_owned());
@@ -264,10 +264,9 @@ fn prepare_script(upstreams: &[upstream::Upstream]) -> String {
                     r#"bsdtar-static xf "%(sourcedir)/{rename}" -C "{unpack_dir}" --strip-components={strip_dirs} --no-same-owner || (echo "Failed to extract archive"; exit 1);"#,
                 );
             }
-            upstream::Props::Git { .. } => {
+            upstream::Props::Git { clone_dir, .. } => {
                 let source = util::uri_file_name(&upstream.url);
-                let target = upstream
-                    .unpack_dir
+                let target = clone_dir
                     .as_ref()
                     .map(|dir| dir.display().to_string())
                     .unwrap_or_else(|| source.to_owned());

--- a/boulder/src/cli/build.rs
+++ b/boulder/src/cli/build.rs
@@ -105,7 +105,7 @@ pub fn handle(command: Command, env: Env) -> Result<(), Error> {
     );
     println!("boulder {}", tools_buildinfo::get_simple_version());
     println!("└─ building {pkg_name}-{build_release}\n");
-    let shared_upstreams = builder.setup(&mut timing, timer, update)?;
+    builder.setup(&mut timing, timer, update)?;
 
     let paths = &builder.paths;
     let networking = builder.recipe.parsed.options.networking;
@@ -149,9 +149,6 @@ pub fn handle(command: Command, env: Env) -> Result<(), Error> {
     package::sync_artefacts(paths).map_err(Error::SyncArtefacts)?;
 
     if cleanup {
-        for share in shared_upstreams {
-            share.remove().map_err(|e| Error::Cleanup(build::Error::from(e)))?;
-        }
         builder.cleanup().map_err(Error::Cleanup)?;
     }
 

--- a/boulder/src/cli/build.rs
+++ b/boulder/src/cli/build.rs
@@ -105,7 +105,7 @@ pub fn handle(command: Command, env: Env) -> Result<(), Error> {
     );
     println!("boulder {}", tools_buildinfo::get_simple_version());
     println!("└─ building {pkg_name}-{build_release}\n");
-    builder.setup(&mut timing, timer, update)?;
+    let shared_upstreams = builder.setup(&mut timing, timer, update)?;
 
     let paths = &builder.paths;
     let networking = builder.recipe.parsed.options.networking;
@@ -149,6 +149,9 @@ pub fn handle(command: Command, env: Env) -> Result<(), Error> {
     package::sync_artefacts(paths).map_err(Error::SyncArtefacts)?;
 
     if cleanup {
+        for share in shared_upstreams {
+            share.remove().map_err(|e| Error::Cleanup(build::Error::from(e)))?;
+        }
         builder.cleanup().map_err(Error::Cleanup)?;
     }
 

--- a/boulder/src/cli/build.rs
+++ b/boulder/src/cli/build.rs
@@ -177,19 +177,14 @@ fn verify_versions_match(builder: &Builder) -> Result<(), Error> {
 
     // We won't attempt to parse git upstreams for now
     match &first_upstream.props {
-        stone_recipe::upstream::Props::Git { git_ref, staging: _ } => {
+        stone_recipe::upstream::Props::Git { git_ref, .. } => {
             // If we have a git ref, we have a git upstream and version parsing
             // will not work.
             if !git_ref.is_empty() {
                 return Ok(());
             }
         }
-        stone_recipe::upstream::Props::Plain {
-            hash: _,
-            rename: _,
-            strip_dirs: _,
-            unpack: _,
-        } => {}
+        stone_recipe::upstream::Props::Plain { .. } => {}
     }
 
     let ver_ext = VersionExtractor::new();

--- a/boulder/src/upstream.rs
+++ b/boulder/src/upstream.rs
@@ -162,7 +162,7 @@ pub fn sync(upstreams: &[Upstream], storage_dir: &Path, share_dir: &Path) -> Res
             .map(async |upstream| -> Result<Shared, Error> {
                 let pb = mp.insert_before(
                     &tp,
-                    ProgressBar::new(u64::MAX).with_prefix(format!(
+                    ProgressBar::new(u64::MAX).with_message(format!(
                         "{} {}",
                         "Downloading".blue(),
                         upstream.name().bold(),

--- a/boulder/src/upstream.rs
+++ b/boulder/src/upstream.rs
@@ -5,6 +5,7 @@
 use std::{io, path::Path, time::Duration};
 
 use crate::recipe::Recipe;
+use fs_err as fs;
 use futures_util::{StreamExt, TryStreamExt, stream};
 use moss::runtime;
 use stone_recipe::upstream;
@@ -34,7 +35,7 @@ pub enum Upstream {
 impl Upstream {
     /// Constructs an [Upstream] based on the information provided
     /// in the `upstream` section of a Stone recipe.
-    pub fn from_recipe_upstream(upstream: upstream::Upstream) -> Result<Self, Error> {
+    pub fn from_recipe_upstream(upstream: upstream::Upstream, original_index: usize) -> Result<Self, Error> {
         match upstream.props {
             upstream::Props::Plain { hash, rename, .. } => Ok(Self::Plain(Plain {
                 url: upstream.url,
@@ -44,6 +45,7 @@ impl Upstream {
             upstream::Props::Git { git_ref, .. } => Ok(Self::Git(Git {
                 url: upstream.url,
                 commit: git_ref,
+                original_index,
             })),
         }
     }
@@ -138,12 +140,18 @@ pub fn parse_recipe(recipe: &Recipe) -> Result<Vec<Upstream>, Error> {
         .upstreams
         .iter()
         .cloned()
-        .map(Upstream::from_recipe_upstream)
+        .enumerate()
+        .map(|(index, upstream)| Upstream::from_recipe_upstream(upstream, index))
         .collect()
 }
 
 /// Helper that stores and shares a list of [Upstream]s.
-pub fn sync(upstreams: &[Upstream], storage_dir: &Path, share_dir: &Path) -> Result<Vec<Shared>, Error> {
+pub fn sync(
+    recipe: &Recipe,
+    upstreams: &[Upstream],
+    storage_dir: &Path,
+    share_dir: &Path,
+) -> Result<Vec<Stored>, Error> {
     println!();
     println!("Sharing {} upstream(s) with the build container", upstreams.len());
 
@@ -157,9 +165,9 @@ pub fn sync(upstreams: &[Upstream], storage_dir: &Path, share_dir: &Path) -> Res
     );
     tp.tick();
 
-    let shared = runtime::block_on(
+    let stored = runtime::block_on(
         stream::iter(upstreams)
-            .map(async |upstream| -> Result<Shared, Error> {
+            .map(|upstream| async {
                 let pb = mp.insert_before(
                     &tp,
                     ProgressBar::new(u64::MAX).with_message(format!(
@@ -179,7 +187,7 @@ pub fn sync(upstreams: &[Upstream], storage_dir: &Path, share_dir: &Path) -> Res
                         .tick_chars("--=≡■≡=--"),
                 );
 
-                let shared = stored.share(share_dir).await?;
+                stored.share(share_dir).await?;
 
                 let cached_tag = stored
                     .was_cached()
@@ -191,16 +199,24 @@ pub fn sync(upstreams: &[Upstream], storage_dir: &Path, share_dir: &Path) -> Res
                 mp.suspend(|| println!("{} {}{cached_tag}", "Shared".green(), upstream.name().bold()));
                 tp.inc(1);
 
-                Ok(shared)
+                Ok(stored) as Result<_, Error>
             })
             .buffer_unordered(moss::environment::MAX_NETWORK_CONCURRENCY)
-            .try_collect(),
+            .try_collect::<Vec<_>>(),
     )?;
+
+    if let Some(updated_yaml) = update_git_upstream_refs(&recipe.source, &stored) {
+        fs::write(&recipe.path, updated_yaml)?;
+        println!(
+            "{} | Git references resolved to commit hashes and saved to stone.yaml. This ensures reproducible builds since tags and branches can move over time.",
+            "Warning".yellow()
+        );
+    }
 
     mp.clear()?;
     println!();
 
-    Ok(shared)
+    Ok(stored)
 }
 
 /// Helper that removes a list of [Upstream]s from the storage directory.
@@ -223,4 +239,189 @@ pub enum Error {
     #[error("io")]
     // A generic I/O error occurred.
     Io(#[from] io::Error),
+}
+
+/// Process git upstreams after cloning and return updated YAML if refs differ from resolved hashes.
+pub(crate) fn update_git_upstream_refs(recipe_source: &str, stored_upstreams: &[Stored]) -> Option<String> {
+    let mut yaml_updater = yaml::Updater::new();
+    let mut refs_updated = false;
+
+    for stored in stored_upstreams.iter() {
+        if let Stored::Git(git) = stored
+            && git.resolved_hash != git.original_ref
+        {
+            update_git_upstream_ref_in_yaml(
+                &mut yaml_updater,
+                git.original_index,
+                git.url.as_str(),
+                &git.resolved_hash,
+                &git.original_ref,
+            );
+            println!(
+                "{} | Updated ref '{}' to commit {} for {}",
+                "Warning".yellow(),
+                &git.resolved_hash[..8],
+                &git.original_ref,
+                &git.url.as_str()
+            );
+            refs_updated = true;
+        }
+    }
+
+    if refs_updated {
+        Some(yaml_updater.apply(recipe_source))
+    } else {
+        None
+    }
+}
+
+/// Replaces the non-hash refs for git upstreams with the hash for the given ref
+/// and includes a comment showing the original ref.
+fn update_git_upstream_ref_in_yaml(
+    updater: &mut yaml::Updater,
+    upstream_index: usize,
+    url: &str,
+    new_ref: &str,
+    original_ref: &str,
+) {
+    let git_key = format!("git|{url}");
+    let new_value_with_comment = format!("{new_ref} # {original_ref}");
+
+    // git|url: <ref>
+    updater.update_value(&new_value_with_comment, |p| {
+        p / "upstreams" / upstream_index / git_key.as_str()
+    });
+
+    // git|url:
+    // - ref: <ref>
+    // ...
+    updater.update_value(&new_value_with_comment, |p| {
+        p / "upstreams" / upstream_index / git_key.as_str() / "ref"
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::upstream::StoredGit;
+    use crate::upstream::plain::StoredPlain;
+
+    use super::*;
+
+    use url::Url;
+
+    #[test]
+    fn test_update_git_upstream_refs() {
+        let recipe_source = r#"
+upstreams:
+  - git|https://github.com/example/repo1.git: main
+  - git|https://github.com/example/repo2.git:
+      ref: main
+  - git|https://github.com/example/repo3.git: abcd1234567890abcdef1234567890abcdef1234
+  - git|https://github.com/example/repo4.git: abc123d
+  - https://example.com/file.tar.gz: some-hash
+"#;
+
+        let stored = vec![
+            Stored::Git(StoredGit {
+                name: "repo1.git".to_owned(),
+                repo: gitwrap::NULL_REPOSITORY,
+                was_cached: false,
+                url: Url::parse("https://github.com/example/repo1.git").unwrap(),
+                original_ref: "main".to_owned(),
+                resolved_hash: "1111222233334444555566667777888899990000".to_owned(),
+                original_index: 0,
+            }),
+            Stored::Git(StoredGit {
+                name: "repo2.git".to_owned(),
+                repo: gitwrap::NULL_REPOSITORY,
+                was_cached: false,
+                url: Url::parse("https://github.com/example/repo2.git").unwrap(),
+                original_ref: "main".to_owned(),
+                resolved_hash: "aaaa1111bbbb2222cccc3333dddd4444eeee5555".to_owned(),
+                original_index: 1,
+            }),
+            Stored::Git(StoredGit {
+                name: "repo3.git".to_owned(),
+                repo: gitwrap::NULL_REPOSITORY,
+                was_cached: false,
+                url: Url::parse("https://github.com/example/repo3.git").unwrap(),
+                original_ref: "abcd1234567890abcdef1234567890abcdef1234".to_owned(),
+                resolved_hash: "abcd1234567890abcdef1234567890abcdef1234".to_owned(),
+                original_index: 2,
+            }),
+            Stored::Git(StoredGit {
+                name: "repo4.git".to_owned(),
+                repo: gitwrap::NULL_REPOSITORY,
+                was_cached: false,
+                url: Url::parse("https://github.com/example/repo4.git").unwrap(),
+                original_ref: "abc123d".to_owned(),
+                resolved_hash: "abc123d567890abcdef1234567890abcdef12345".to_owned(),
+                original_index: 3,
+            }),
+            Stored::Git(StoredGit {
+                name: "file.tar.gz".to_owned(),
+                repo: gitwrap::NULL_REPOSITORY,
+                was_cached: false,
+                // We don't care about the values below.
+                url: "http://example.com".try_into().unwrap(),
+                original_ref: String::new(),
+                resolved_hash: String::new(),
+                original_index: 0,
+            }),
+        ];
+
+        let result = update_git_upstream_refs(recipe_source, &stored);
+
+        assert!(result.is_some());
+        let updated_yaml = result.unwrap();
+
+        // Should update short form ref to hash with comment
+        assert!(updated_yaml.contains("1111222233334444555566667777888899990000 # main"));
+
+        // Should update long form ref to hash with comment
+        assert!(updated_yaml.contains("aaaa1111bbbb2222cccc3333dddd4444eeee5555 # main"));
+
+        // Should not change hash that's already a hash
+        assert!(updated_yaml.contains("abcd1234567890abcdef1234567890abcdef1234"));
+        assert!(
+            !updated_yaml
+                .contains("abcd1234567890abcdef1234567890abcdef1234 # abcd1234567890abcdef1234567890abcdef1234")
+        );
+
+        // Should update short hash to long hash
+        assert!(updated_yaml.contains("abc123d567890abcdef1234567890abcdef12345 # abc123d"));
+
+        // Should preserve non-git upstreams unchanged
+        assert!(updated_yaml.contains("https://example.com/file.tar.gz: some-hash"));
+    }
+
+    #[test]
+    fn test_update_git_upstream_refs_no_updates() {
+        let recipe_source = r#"
+upstreams:
+  - git|https://github.com/example/repo3.git: abcd1234567890abcdef1234567890abcdef1234
+  - https://example.com/file.tar.gz: some-hash
+"#;
+
+        let stored = vec![
+            Stored::Git(StoredGit {
+                name: "repo3.git".to_owned(),
+                repo: gitwrap::NULL_REPOSITORY,
+                was_cached: false,
+                url: Url::parse("https://github.com/example/repo3.git").unwrap(),
+                original_ref: "abcd1234567890abcdef1234567890abcdef1234".to_owned(),
+                resolved_hash: "abcd1234567890abcdef1234567890abcdef1234".to_owned(),
+                original_index: 0,
+            }),
+            Stored::Plain(StoredPlain {
+                name: "file.tar.gz".to_owned(),
+                path: "/tmp/file.tar.gz".into(),
+                was_cached: false,
+            }),
+        ];
+
+        let result = update_git_upstream_refs(recipe_source, &stored);
+
+        assert!(result.is_none());
+    }
 }

--- a/boulder/src/upstream.rs
+++ b/boulder/src/upstream.rs
@@ -4,55 +4,53 @@
 
 use std::{io, path::Path, time::Duration};
 
-use fs_err as fs;
+use crate::recipe::Recipe;
 use futures_util::{StreamExt, TryStreamExt, stream};
-use moss::{runtime, util};
-use nix::unistd::{LinkatFlags, linkat};
-use stone_recipe::upstream::{self, SourceUri};
+use moss::runtime;
+use stone_recipe::upstream;
 use thiserror::Error;
 use tui::{MultiProgress, ProgressBar, ProgressStyle, Styled};
 
-use crate::{
-    Paths, Recipe,
-    upstream::{
-        git::{Git, StoredGit},
-        plain::{Plain, StoredPlain},
-    },
+use crate::upstream::{
+    git::{Git, SharedGit, StoredGit},
+    plain::{Plain, SharedPlain, StoredPlain},
 };
 
-pub mod git;
-pub mod plain;
+mod git;
+mod plain;
 
+/// An upstream is a backend where
+/// to get source code from.
 #[derive(Debug, Clone)]
 pub enum Upstream {
+    /// An archive containing source code, typically
+    /// a tarball. In order to be usable, it must compatible with
+    /// [bsdtar](https://man.freebsd.org/cgi/man.cgi?query=bsdtar&sektion=1&format=html).
     Plain(Plain),
+    /// The source code is from a Git repository.
     Git(Git),
 }
 
 impl Upstream {
-    pub fn from_recipe(upstream: upstream::Upstream, original_index: usize) -> Result<Self, Error> {
+    /// Constructs an [Upstream] based on the information provided
+    /// in the `upstream` section of a Stone recipe.
+    pub fn from_recipe_upstream(upstream: upstream::Upstream) -> Result<Self, Error> {
         match upstream.props {
             upstream::Props::Plain { hash, rename, .. } => Ok(Self::Plain(Plain {
                 url: upstream.url,
                 hash: hash.parse().map_err(plain::Error::from)?,
                 rename,
             })),
-            upstream::Props::Git { git_ref, staging } => Ok(Self::Git(Git {
-                uri: upstream.url,
-                ref_id: git_ref,
-                staging,
-                original_index,
+            upstream::Props::Git { git_ref, .. } => Ok(Self::Git(Git {
+                url: upstream.url,
+                commit: git_ref,
             })),
         }
     }
 
-    pub async fn _fetch_new(uri: SourceUri, dest: &Path) -> Result<Self, Error> {
-        Ok(match uri.kind {
-            upstream::Kind::Archive => Self::Plain(Plain::_fetch_new(uri.url, dest).await?),
-            upstream::Kind::Git => Self::Git(Git::_fetch_new(&uri.url, dest).await?),
-        })
-    }
-
+    /// Returns the name of the upstream. This is an informal
+    /// name used for logging or when a path to be created
+    /// doesn't need to be unique.
     fn name(&self) -> &str {
         match self {
             Upstream::Plain(plain) => plain.name(),
@@ -60,30 +58,40 @@ impl Upstream {
         }
     }
 
-    async fn store(&self, paths: &Paths, pb: &ProgressBar) -> Result<Stored, Error> {
+    /// Stores the upstream into the storage directory.
+    /// The final path contained in the storage directory, and the write logic,
+    /// depend on the upstream variant. The final path where the upstream is stored
+    /// is unique inside the storage directory.
+    async fn store(&self, storage_dir: &Path, pb: &ProgressBar) -> Result<Stored, Error> {
         Ok(match self {
-            Upstream::Plain(plain) => Stored::Plain(plain.store(paths, pb).await?),
-            Upstream::Git(git) => Stored::Git(git.store(paths, pb).await?),
+            Upstream::Plain(plain) => Stored::Plain(plain.store(storage_dir, pb).await?),
+            Upstream::Git(git) => Stored::Git(git.store(storage_dir, pb).await?),
         })
     }
 
-    fn remove(&self, paths: &Paths) -> Result<(), Error> {
+    /// Unconditionally removes this Upstream's resources within the storage directory.
+    /// If the resources do not exist, this function returns successfully
+    /// (it is idempotent).
+    ///
+    /// Careful: this function does not validate the content!
+    /// It will be removed even if it does not belong to this Upstream.
+    fn remove(&self, storage_dir: &Path) -> Result<(), Error> {
         match self {
-            Upstream::Plain(plain) => plain.remove(paths)?,
-            Upstream::Git(git) => git.remove(paths)?,
+            Upstream::Plain(plain) => plain.remove(storage_dir).map_err(Error::from),
+            Upstream::Git(git) => git.remove(storage_dir).map_err(Error::from),
         }
-
-        Ok(())
     }
 }
 
-#[derive(Clone)]
+/// Information available after [Upstream] is stored on disk.
 pub(crate) enum Stored {
     Plain(StoredPlain),
     Git(StoredGit),
 }
 
 impl Stored {
+    /// Whether the upstream did not need to be written at the moment
+    /// of being stored, because the constant was already there and valid.
     fn was_cached(&self) -> bool {
         match self {
             Stored::Plain(plain) => plain.was_cached,
@@ -91,43 +99,51 @@ impl Stored {
         }
     }
 
-    fn share(&self, dest_dir: &Path) -> Result<(), Error> {
+    /// Shares the upstream in preparation of a build.
+    ///
+    /// This function tries to be as efficient as possible in terms
+    /// of actual bytes written/copied, by linking files from the storage directory.
+    async fn share(&self, dest_dir: &Path) -> Result<Shared, Error> {
+        Ok(match self {
+            Stored::Plain(plain) => Shared::Plain(plain.share(dest_dir)?),
+            Stored::Git(git) => Shared::Git(git.share(&dest_dir.join(&git.name)).await?),
+        })
+    }
+}
+
+/// A shared upstream is a copy of an upstream
+/// in a location useful for a build.
+pub enum Shared {
+    Plain(SharedPlain),
+    Git(SharedGit),
+}
+
+impl Shared {
+    /// Removes the shared upstream.
+    /// Should the upstream no longer exist,
+    /// this function returns successfully (it is idempotent).
+    pub fn remove(&self) -> Result<(), Error> {
         match self {
-            Stored::Plain(plain) => {
-                let target = dest_dir.join(plain.name.clone());
-
-                // Attempt hard link
-                let link_result = linkat(None, &plain.path, None, &target, LinkatFlags::NoSymlinkFollow);
-
-                // Copy instead
-                if link_result.is_err() {
-                    fs::copy(plain.path.clone(), &target)?;
-                }
-            }
-            Stored::Git(git) => {
-                let target = dest_dir.join(git.name.clone());
-                util::copy_dir(&git.path, &target)?;
-            }
-        }
-
+            Self::Plain(plain) => plain.remove()?,
+            Self::Git(git) => git.remove()?,
+        };
         Ok(())
     }
 }
 
-pub fn parse(recipe: &Recipe) -> Result<Vec<Upstream>, Error> {
+/// Returns a list of upstream from a Stone recipe.
+pub fn parse_recipe(recipe: &Recipe) -> Result<Vec<Upstream>, Error> {
     recipe
         .parsed
         .upstreams
         .iter()
         .cloned()
-        .enumerate()
-        .map(|(index, upstream)| Upstream::from_recipe(upstream, index))
+        .map(Upstream::from_recipe_upstream)
         .collect()
 }
 
-/// Cache all upstreams from the provided [`Recipe`], make them available
-/// in the guest rootfs, and update the stone.yaml with resolved git upstream hashes.
-pub fn sync(recipe: &Recipe, paths: &Paths, upstreams: &[Upstream]) -> Result<(), Error> {
+/// Helper that stores and shares a list of [Upstream]s.
+pub fn sync(upstreams: &[Upstream], storage_dir: &Path, share_dir: &Path) -> Result<Vec<Shared>, Error> {
     println!();
     println!("Sharing {} upstream(s) with the build container", upstreams.len());
 
@@ -141,15 +157,12 @@ pub fn sync(recipe: &Recipe, paths: &Paths, upstreams: &[Upstream]) -> Result<()
     );
     tp.tick();
 
-    let upstream_dir = paths.guest_host_path(&paths.upstreams());
-    util::ensure_dir_exists(&upstream_dir)?;
-
-    let installed_upstreams = runtime::block_on(
+    let shared = runtime::block_on(
         stream::iter(upstreams)
-            .map(|upstream| async {
+            .map(async |upstream| -> Result<Shared, Error> {
                 let pb = mp.insert_before(
                     &tp,
-                    ProgressBar::new(u64::MAX).with_message(format!(
+                    ProgressBar::new(u64::MAX).with_prefix(format!(
                         "{} {}",
                         "Downloading".blue(),
                         upstream.name().bold(),
@@ -157,7 +170,7 @@ pub fn sync(recipe: &Recipe, paths: &Paths, upstreams: &[Upstream]) -> Result<()
                 );
                 pb.enable_steady_tick(Duration::from_millis(150));
 
-                let install = upstream.store(paths, &pb).await?;
+                let stored = upstream.store(storage_dir, &pb).await?;
 
                 pb.set_message(format!("{} {}", "Copying".yellow(), upstream.name().bold()));
                 pb.set_style(
@@ -166,14 +179,9 @@ pub fn sync(recipe: &Recipe, paths: &Paths, upstreams: &[Upstream]) -> Result<()
                         .tick_chars("--=≡■≡=--"),
                 );
 
-                runtime::unblock({
-                    let install = install.clone();
-                    let dir = upstream_dir.clone();
-                    move || install.share(&dir)
-                })
-                .await?;
+                let shared = stored.share(share_dir).await?;
 
-                let cached_tag = install
+                let cached_tag = stored
                     .was_cached()
                     .then_some(format!("{}", " (cached)".dim()))
                     .unwrap_or_default();
@@ -183,47 +191,36 @@ pub fn sync(recipe: &Recipe, paths: &Paths, upstreams: &[Upstream]) -> Result<()
                 mp.suspend(|| println!("{} {}{cached_tag}", "Shared".green(), upstream.name().bold()));
                 tp.inc(1);
 
-                Ok(install) as Result<_, Error>
+                Ok(shared)
             })
             .buffer_unordered(moss::environment::MAX_NETWORK_CONCURRENCY)
-            .try_collect::<Vec<_>>(),
+            .try_collect(),
     )?;
-
-    if let Some(updated_yaml) = git::update_git_upstream_refs(&recipe.source, &installed_upstreams)? {
-        fs::write(&recipe.path, updated_yaml)?;
-        println!(
-            "{} | Git references resolved to commit hashes and saved to stone.yaml. This ensures reproducible builds since tags and branches can move over time.",
-            "Warning".yellow()
-        );
-    }
 
     mp.clear()?;
     println!();
 
-    Ok(())
+    Ok(shared)
 }
 
-pub fn remove(paths: &Paths, upstreams: &[Upstream]) -> Result<(), Error> {
+/// Helper that removes a list of [Upstream]s from the storage directory.
+pub fn remove(storage_dir: &Path, upstreams: &[Upstream]) -> Result<(), Error> {
     for upstream in upstreams {
-        upstream.remove(paths)?;
+        upstream.remove(storage_dir)?;
     }
-
     Ok(())
 }
 
+/// Possible errors returned by functions in this module.
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("plain")]
+    /// An error occurred while dealing with an archive-based [Upstream].
+    Plain(#[from] plain::Error),
+    /// An error occurred while dealing with a Git-based [Upstream].
     #[error("git")]
     Git(#[from] git::Error),
-    // FIXME: this error comes from a module that
-    // used to live on its own. Now it's merged into this one,
-    // thus there is no need for duplicated error types.
-    #[error("git")]
-    GitOperation(#[from] git::GitError),
     #[error("io")]
+    // A generic I/O error occurred.
     Io(#[from] io::Error),
-    #[error("plain")]
-    Plain(#[from] plain::Error),
-    #[error("request")]
-    Request(#[from] moss::request::Error),
 }

--- a/boulder/src/upstream.rs
+++ b/boulder/src/upstream.rs
@@ -13,8 +13,8 @@ use thiserror::Error;
 use tui::{MultiProgress, ProgressBar, ProgressStyle, Styled};
 
 use crate::upstream::{
-    git::{Git, SharedGit, StoredGit},
-    plain::{Plain, SharedPlain, StoredPlain},
+    git::{Git, StoredGit},
+    plain::{Plain, StoredPlain},
 };
 
 mod git;
@@ -105,30 +105,11 @@ impl Stored {
     ///
     /// This function tries to be as efficient as possible in terms
     /// of actual bytes written/copied, by linking files from the storage directory.
-    async fn share(&self, dest_dir: &Path) -> Result<Shared, Error> {
-        Ok(match self {
-            Stored::Plain(plain) => Shared::Plain(plain.share(dest_dir)?),
-            Stored::Git(git) => Shared::Git(git.share(&dest_dir.join(&git.name)).await?),
-        })
-    }
-}
-
-/// A shared upstream is a copy of an upstream
-/// in a location useful for a build.
-pub enum Shared {
-    Plain(SharedPlain),
-    Git(SharedGit),
-}
-
-impl Shared {
-    /// Removes the shared upstream.
-    /// Should the upstream no longer exist,
-    /// this function returns successfully (it is idempotent).
-    pub fn remove(&self) -> Result<(), Error> {
+    async fn share(&self, dest_dir: &Path) -> Result<(), Error> {
         match self {
-            Self::Plain(plain) => plain.remove()?,
-            Self::Git(git) => git.remove()?,
-        };
+            Stored::Plain(plain) => plain.share(dest_dir)?,
+            Stored::Git(git) => git.share(&dest_dir.join(&git.name)).await?,
+        }
         Ok(())
     }
 }
@@ -324,7 +305,7 @@ upstreams:
         let stored = vec![
             Stored::Git(StoredGit {
                 name: "repo1.git".to_owned(),
-                repo: gitwrap::NULL_REPOSITORY,
+                repo: gitwrap::null_repository(),
                 was_cached: false,
                 url: Url::parse("https://github.com/example/repo1.git").unwrap(),
                 original_ref: "main".to_owned(),
@@ -333,7 +314,7 @@ upstreams:
             }),
             Stored::Git(StoredGit {
                 name: "repo2.git".to_owned(),
-                repo: gitwrap::NULL_REPOSITORY,
+                repo: gitwrap::null_repository(),
                 was_cached: false,
                 url: Url::parse("https://github.com/example/repo2.git").unwrap(),
                 original_ref: "main".to_owned(),
@@ -342,7 +323,7 @@ upstreams:
             }),
             Stored::Git(StoredGit {
                 name: "repo3.git".to_owned(),
-                repo: gitwrap::NULL_REPOSITORY,
+                repo: gitwrap::null_repository(),
                 was_cached: false,
                 url: Url::parse("https://github.com/example/repo3.git").unwrap(),
                 original_ref: "abcd1234567890abcdef1234567890abcdef1234".to_owned(),
@@ -351,7 +332,7 @@ upstreams:
             }),
             Stored::Git(StoredGit {
                 name: "repo4.git".to_owned(),
-                repo: gitwrap::NULL_REPOSITORY,
+                repo: gitwrap::null_repository(),
                 was_cached: false,
                 url: Url::parse("https://github.com/example/repo4.git").unwrap(),
                 original_ref: "abc123d".to_owned(),
@@ -360,7 +341,7 @@ upstreams:
             }),
             Stored::Git(StoredGit {
                 name: "file.tar.gz".to_owned(),
-                repo: gitwrap::NULL_REPOSITORY,
+                repo: gitwrap::null_repository(),
                 was_cached: false,
                 // We don't care about the values below.
                 url: "http://example.com".try_into().unwrap(),
@@ -406,7 +387,7 @@ upstreams:
         let stored = vec![
             Stored::Git(StoredGit {
                 name: "repo3.git".to_owned(),
-                repo: gitwrap::NULL_REPOSITORY,
+                repo: gitwrap::null_repository(),
                 was_cached: false,
                 url: Url::parse("https://github.com/example/repo3.git").unwrap(),
                 original_ref: "abcd1234567890abcdef1234567890abcdef1234".to_owned(),

--- a/boulder/src/upstream/git.rs
+++ b/boulder/src/upstream/git.rs
@@ -134,27 +134,34 @@ pub struct StoredGit {
 
 impl StoredGit {
     /// Shares the Git repository in preparation of a build.
-    ///
-    /// This function tries to be as efficient as possible in terms
-    /// of actual bytes written/copied from the original Git repository.
     pub async fn share(&self, dest_dir: &Path) -> Result<SharedGit, Error> {
         if let Some(parent) = dest_dir.parent() {
             fs::create_dir_all(parent)?;
         }
-        Ok(SharedGit(self.repo.add_worktree(dest_dir, &self.commit).await?))
+
+        // Clone from our mirror to destdir
+        let cloned = self.repo.clone_to(dest_dir).await?;
+
+        // Cloning sets origin to the local mirror, but we want to use
+        // the original remote as submodule resolving may depend on this
+        let source_origin = self.repo.get_remote_url("origin").await?;
+        cloned.set_remote_url("origin", &source_origin).await?;
+
+        // Finally checkout the desired commit
+        cloned.checkout(&self.commit).await?;
+
+        Ok(SharedGit(dest_dir.to_owned()))
     }
 }
 
 /// A shared Git repository is a copy of a stored Git
 /// in a location useful for a build.
-pub struct SharedGit(gitwrap::Worktree);
+pub struct SharedGit(PathBuf);
 
 impl SharedGit {
     /// Removes the shared Git repository.
-    /// Should the shared repository no longer exist,
-    /// this function returns successfully (it is idempotent).
     pub fn remove(&self) -> Result<(), Error> {
-        self.0.remove_sync().map_err(Error::from)
+        fs::remove_dir_all(&self.0).map_err(Error::from)
     }
 }
 

--- a/boulder/src/upstream/git.rs
+++ b/boulder/src/upstream/git.rs
@@ -188,8 +188,6 @@ async fn fetch(repo: &gitwrap::Repository, pb: &ProgressBar) -> Result<(), gitwr
 }
 
 fn set_progress_bar_style(pb: &ProgressBar) -> impl Fn(gitwrap::FetchProgress) {
-    use tui::HumanBytes;
-
     pb.set_length(100);
     pb.set_style(
         ProgressStyle::with_template("{prefix}\n|{bar:20.cyan/bue}| {percent}% {msg:>.dim}")
@@ -199,6 +197,6 @@ fn set_progress_bar_style(pb: &ProgressBar) -> impl Fn(gitwrap::FetchProgress) {
 
     |prog| {
         pb.set_position(prog.percent as u64);
-        pb.set_message(format!("{}/s", HumanBytes(prog.speed)));
+        pb.set_message(prog.speed);
     }
 }

--- a/boulder/src/upstream/git.rs
+++ b/boulder/src/upstream/git.rs
@@ -20,6 +20,7 @@ pub struct Git {
     pub url: Url,
     /// Hash of the commit to be considered as source.
     pub commit: String,
+    pub original_index: usize,
 }
 
 impl Git {
@@ -50,17 +51,16 @@ impl Git {
             Err(Error::Io(e)) => return Err(Error::from(e)),
         }
 
-        // When we reach this point, the repository may still
-        // not have the commit ID (e.g. because the ID
-        // was wrongly typed in the first place). This is acceptable
-        // because we managed to store the repository nonetheless.
-        // Users will receive an error when calling StoredGit::share.
+        let resolved_hash = repo.peel_commit(&self.commit).await?;
 
         Ok(StoredGit {
             name: self.name().to_owned(),
             was_cached: cached,
             repo,
-            commit: self.commit.to_owned(),
+            url: self.url.clone(),
+            original_ref: self.commit.to_owned(),
+            resolved_hash,
+            original_index: self.original_index,
         })
     }
 
@@ -85,12 +85,16 @@ impl Git {
     pub async fn stored(&self, storage_dir: &Path) -> Result<(StoredGit, bool), Error> {
         let repo = gitwrap::Repository::open_bare(&self.stored_path(storage_dir)).await?;
         let has_ref = repo.has_commit(&self.commit).await?;
+        let resolved_hash = repo.peel_commit(&self.commit).await?;
         Ok((
             StoredGit {
                 name: self.name().to_owned(),
                 was_cached: has_ref,
                 repo,
-                commit: self.commit.to_owned(),
+                url: self.url.clone(),
+                original_ref: self.commit.to_owned(),
+                resolved_hash,
+                original_index: self.original_index,
             },
             has_ref,
         ))
@@ -128,8 +132,11 @@ pub struct StoredGit {
     /// synchronized with [Git],
     /// that is, it existed and contained [Git::commit].
     pub was_cached: bool,
-    repo: gitwrap::Repository,
-    commit: String,
+    pub url: Url,
+    pub original_ref: String,
+    pub resolved_hash: String,
+    pub original_index: usize,
+    pub repo: gitwrap::Repository,
 }
 
 impl StoredGit {
@@ -148,7 +155,7 @@ impl StoredGit {
         cloned.set_remote_url("origin", &source_origin).await?;
 
         // Finally checkout the desired commit
-        cloned.checkout(&self.commit).await?;
+        cloned.checkout(&self.resolved_hash).await?;
 
         Ok(SharedGit(dest_dir.to_owned()))
     }

--- a/boulder/src/upstream/git.rs
+++ b/boulder/src/upstream/git.rs
@@ -73,7 +73,7 @@ impl Git {
     /// of the directory! Resources will be deleted even if they
     /// do not belong to a Git repository.
     pub fn remove(&self, storage_dir: &Path) -> Result<(), Error> {
-        let dir = storage_dir.join(self.directory_name());
+        let dir = self.stored_path(storage_dir);
         util::remove_dir_all(&dir).map_err(Error::from)
     }
 

--- a/boulder/src/upstream/git.rs
+++ b/boulder/src/upstream/git.rs
@@ -190,13 +190,13 @@ async fn fetch(repo: &gitwrap::Repository, pb: &ProgressBar) -> Result<(), gitwr
 fn set_progress_bar_style(pb: &ProgressBar) -> impl Fn(gitwrap::FetchProgress) {
     pb.set_length(100);
     pb.set_style(
-        ProgressStyle::with_template("{prefix}\n|{bar:20.cyan/bue}| {percent}% {msg:>.dim}")
+        ProgressStyle::with_template(" {spinner} |{percent:>3}%| {wide_msg} {prefix:>.dim} ")
             .unwrap()
-            .progress_chars("■≡=- "),
+            .tick_chars("--=≡■≡=--"),
     );
 
     |prog| {
         pb.set_position(prog.percent as u64);
-        pb.set_message(prog.speed);
+        pb.set_prefix(prog.speed);
     }
 }

--- a/boulder/src/upstream/git.rs
+++ b/boulder/src/upstream/git.rs
@@ -113,9 +113,9 @@ impl Git {
         let mut name = String::with_capacity(host.unwrap_or("").len() + 1 + path.len());
         if let Some(host) = host {
             name.push_str(host);
-            name.push('.');
+            name.push('_');
         }
-        name.push_str(&path.replace('/', "."));
+        name.push_str(&path.trim_start_matches('/').replace('/', "."));
         name.into()
     }
 }

--- a/boulder/src/upstream/git.rs
+++ b/boulder/src/upstream/git.rs
@@ -5,554 +5,200 @@
 use std::{
     io,
     path::{Path, PathBuf},
-    process, string,
 };
 
-use moss::{runtime, util};
+use fs_err as fs;
+use moss::util;
 use thiserror::Error;
-use tui::{ProgressBar, ProgressStyle, Styled};
+use tui::{ProgressBar, ProgressStyle};
 use url::Url;
 
-use crate::{Paths, upstream::Stored};
-
+/// Upstream based on a Git repository.
 #[derive(Clone, Debug)]
 pub struct Git {
-    pub uri: Url,
-    pub ref_id: String,
-    pub staging: bool,
-    pub original_index: usize,
+    /// URL of origin.
+    pub url: Url,
+    /// Hash of the commit to be considered as source.
+    pub commit: String,
 }
 
 impl Git {
-    pub async fn _fetch_new(url: &Url, dest_dir: &Path) -> Result<Self, Error> {
-        Self::_fetch_new_progress(url, dest_dir, &ProgressBar::hidden()).await
-    }
-
-    pub async fn _fetch_new_progress(_url: &Url, _dest_dir: &Path, _pb: &ProgressBar) -> Result<Self, Error> {
-        todo!()
-    }
-
+    /// Returns the name of the upstream. It is implied from the URL.
     pub fn name(&self) -> &str {
-        util::uri_file_name(&self.uri)
+        util::uri_file_name(&self.url)
     }
 
-    fn final_path(&self, paths: &Paths) -> PathBuf {
-        paths
-            .upstreams()
-            .host
-            .join("git")
-            .join(util::uri_relative_path(&self.uri))
-    }
-
-    fn staging_path(&self, paths: &Paths) -> PathBuf {
-        paths
-            .upstreams()
-            .host
-            .join("staging")
-            .join("git")
-            .join(util::uri_relative_path(&self.uri))
-    }
-
-    pub async fn store(&self, paths: &Paths, pb: &ProgressBar) -> Result<StoredGit, Error> {
-        use fs_err::tokio as fs;
-
-        pb.set_style(
-            ProgressStyle::with_template(" {spinner} {wide_msg} ")
-                .unwrap()
-                .tick_chars("--=≡■≡=--"),
-        );
-
-        let clone_path = if self.staging {
-            self.staging_path(paths)
-        } else {
-            self.final_path(paths)
-        };
-        let clone_path_string = clone_path.display().to_string();
-
-        let final_path = self.final_path(paths);
-        let final_path_string = final_path.display().to_string();
-
-        if let Some(parent) = clone_path.parent().map(Path::to_path_buf) {
-            runtime::unblock(move || util::ensure_dir_exists(&parent)).await?;
-        }
-        if let Some(parent) = final_path.parent().map(Path::to_path_buf) {
-            runtime::unblock(move || util::ensure_dir_exists(&parent)).await?;
+    /// Stores the upstream into the storage directory.
+    /// If the upstream was already stored but does not include [Self::commit],
+    /// it is updated contextually. If it does not exist, the Git repository is cloned.
+    pub async fn store(&self, storage_dir: &Path, pb: &ProgressBar) -> Result<StoredGit, Error> {
+        let repo: gitwrap::Repository;
+        let mut cached = true;
+        match self.stored(storage_dir).await {
+            Ok((stored, has_commit)) => {
+                repo = stored.repo;
+                if !has_commit {
+                    cached = false;
+                    fetch(&repo, pb).await?;
+                }
+            }
+            Err(Error::Git(_)) => {
+                cached = false;
+                self.remove(storage_dir)?;
+                repo = clone(&self.url, &self.stored_path(storage_dir), pb).await?;
+            }
+            Err(Error::Io(e)) => return Err(Error::from(e)),
         }
 
-        if self.ref_exists(&final_path).await? {
-            self.reset_to_ref(&final_path).await?;
-            let resolved_hash = runtime::unblock({
-                let final_path = final_path.clone();
-                let ref_id = self.ref_id.clone();
-                let uri = self.uri.clone();
-                move || resolve_git_ref(&final_path, &ref_id, &uri)
-            })
-            .await?;
-            return Ok(StoredGit {
-                name: self.name().to_owned(),
-                path: final_path,
-                was_cached: true,
-                uri: self.uri.clone(),
-                original_ref: self.ref_id.clone(),
-                resolved_hash,
-                original_index: self.original_index,
-            });
-        }
-
-        // clean up the dirs we are about to create if they already exist
-        let _ = fs::remove_dir_all(&clone_path).await;
-        if self.staging {
-            let _ = fs::remove_dir_all(&final_path).await;
-        }
-
-        let mut args = vec!["clone"];
-        if self.staging {
-            args.push("--mirror");
-        }
-        args.extend(["--", self.uri.as_str(), &clone_path_string]);
-
-        self.run(&args, None).await?;
-
-        if self.staging {
-            self.run(&["clone", "--", &clone_path_string, &final_path_string], None)
-                .await?;
-        }
-
-        self.reset_to_ref(&final_path).await?;
-
-        let resolved_hash = runtime::unblock({
-            let final_path = final_path.clone();
-            let ref_id = self.ref_id.clone();
-            let uri = self.uri.clone();
-            move || resolve_git_ref(&final_path, &ref_id, &uri)
-        })
-        .await?;
+        // When we reach this point, the repository may still
+        // not have the commit ID (e.g. because the ID
+        // was wrongly typed in the first place). This is acceptable
+        // because we managed to store the repository nonetheless.
+        // Users will receive an error when calling StoredGit::share.
 
         Ok(StoredGit {
             name: self.name().to_owned(),
-            path: final_path,
-            was_cached: false,
-            uri: self.uri.clone(),
-            original_ref: self.ref_id.clone(),
-            resolved_hash,
-            original_index: self.original_index,
+            was_cached: cached,
+            repo,
+            commit: self.commit.to_owned(),
         })
     }
 
-    async fn ref_exists(&self, path: &Path) -> Result<bool, Error> {
-        if !path.exists() {
-            return Ok(false);
-        }
-
-        self.run(&["fetch"], Some(path)).await?;
-
-        let result = self.run(&["cat-file", "-e", &self.ref_id], Some(path)).await;
-
-        Ok(result.is_ok())
+    /// Unconditionally removes the directory, within the storage
+    /// directory, that would store the Git repository.
+    /// If the directory does not exist, this function returns
+    /// successfully (it is idempotent).
+    ///
+    /// Careful: this function does not validate the content
+    /// of the directory! Resources will be deleted even if they
+    /// do not belong to a Git repository.
+    pub fn remove(&self, storage_dir: &Path) -> Result<(), Error> {
+        let dir = storage_dir.join(self.directory_name());
+        util::remove_dir_all(&dir).map_err(Error::from)
     }
 
-    async fn reset_to_ref(&self, path: &Path) -> Result<(), Error> {
-        self.run(&["reset", "--hard", &self.ref_id], Some(path)).await?;
-
-        self.run(
-            &[
-                "submodule",
-                "update",
-                "--init",
-                "--recursive",
-                "--depth",
-                "1",
-                "--jobs",
-                "4",
-            ],
-            Some(path),
-        )
-        .await?;
-
-        Ok(())
+    /// Returns the stored upstream if it exists.
+    ///
+    /// If successful, a tuple is returned containing the
+    /// stored upstream and a boolean flag, indicating whether
+    /// the stored Git repository contains [Self::commit].
+    pub async fn stored(&self, storage_dir: &Path) -> Result<(StoredGit, bool), Error> {
+        let repo = gitwrap::Repository::open_bare(&self.stored_path(storage_dir)).await?;
+        let has_ref = repo.has_commit(&self.commit).await?;
+        Ok((
+            StoredGit {
+                name: self.name().to_owned(),
+                was_cached: has_ref,
+                repo,
+                commit: self.commit.to_owned(),
+            },
+            has_ref,
+        ))
     }
 
-    async fn run(&self, args: &[&str], cwd: Option<&Path>) -> Result<(), Error> {
-        use tokio::process;
-
-        let mut command = process::Command::new("git");
-
-        if let Some(dir) = cwd {
-            command.current_dir(dir);
-        }
-
-        let output = command.args(args).output().await?;
-
-        if !output.status.success() {
-            eprint!("{}", String::from_utf8_lossy(&output.stderr));
-            return Err(Error::GitFailed(self.uri.clone()));
-        }
-
-        Ok(())
+    /// Returns a relative PathBuf where this Git repository
+    /// should be stored within the storage directory.
+    fn stored_path(&self, storage_dir: &Path) -> PathBuf {
+        storage_dir.join("git").join(self.directory_name())
     }
 
-    /// Remove paths while squashing ErrorKind::NotFound errors.
-    pub fn remove(&self, paths: &Paths) -> Result<(), Error> {
-        for path in [self.staging_path(paths), self.final_path(paths)] {
-            util::remove_dir_all(&path)?;
-            if let Some(parent) = path.parent() {
-                util::remove_empty_dirs(parent, &paths.upstreams().host)?;
-            }
+    /// Returns the name of the directory that should contain
+    /// the Git repository.
+    /// It is a composition of the hostname and the repository name
+    /// so that it's unique.
+    fn directory_name(&self) -> PathBuf {
+        let host = self.url.host_str();
+        let path = self.url.path();
+
+        let mut name = String::with_capacity(host.unwrap_or("").len() + 1 + path.len());
+        if let Some(host) = host {
+            name.push_str(host);
+            name.push('.');
         }
-        Ok(())
+        name.push_str(&path.replace('/', "."));
+        name.into()
     }
 }
 
-#[derive(Clone)]
+/// Information available after [Git] is stored on disk.
 pub struct StoredGit {
+    /// Name of the upstream, as returned by [Git::name].
     pub name: String,
-    pub path: PathBuf,
+    /// Whether the stored Git repository was
+    /// synchronized with [Git],
+    /// that is, it existed and contained [Git::commit].
     pub was_cached: bool,
-    pub uri: Url,
-    pub original_ref: String,
-    pub resolved_hash: String,
-    pub original_index: usize,
+    repo: gitwrap::Repository,
+    commit: String,
 }
 
+impl StoredGit {
+    /// Shares the Git repository in preparation of a build.
+    ///
+    /// This function tries to be as efficient as possible in terms
+    /// of actual bytes written/copied from the original Git repository.
+    pub async fn share(&self, dest_dir: &Path) -> Result<SharedGit, Error> {
+        if let Some(parent) = dest_dir.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        Ok(SharedGit(self.repo.add_worktree(dest_dir, &self.commit).await?))
+    }
+}
+
+/// A shared Git repository is a copy of a stored Git
+/// in a location useful for a build.
+pub struct SharedGit(gitwrap::Worktree);
+
+impl SharedGit {
+    /// Removes the shared Git repository.
+    /// Should the shared repository no longer exist,
+    /// this function returns successfully (it is idempotent).
+    pub fn remove(&self) -> Result<(), Error> {
+        self.0.remove_sync().map_err(Error::from)
+    }
+}
+
+/// Possible errors returned by functions in this module.
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("failed to clone {0}")]
-    GitFailed(Url),
-    #[error("git")]
-    Git(#[from] GitError),
-    #[error("io")]
+    /// An error occurred while handling a Git repository.
+    #[error("{0}")]
+    Git(#[from] gitwrap::Error),
+    /// A generic I/O error occurred.
+    #[error("{0}")]
     Io(#[from] io::Error),
 }
 
-#[derive(Debug, Error)]
-pub enum GitError {
-    #[error("ref '{ref_id}' did not resolve to a valid commit hash for {uri}")]
-    UnresolvedRef { ref_id: String, uri: Url },
-    #[error(transparent)]
-    Io(#[from] io::Error),
-    #[error(transparent)]
-    Utf8(#[from] string::FromUtf8Error),
+async fn clone(url: &Url, path: &Path, pb: &ProgressBar) -> Result<gitwrap::Repository, gitwrap::Error> {
+    let cb = set_progress_bar_style(pb);
+
+    let result = gitwrap::Repository::clone_mirror_progress(path, url, cb).await;
+    pb.finish_and_clear();
+
+    result
 }
 
-/// Resolves a git reference to its commit hash using `git rev-parse` on a cloned repo.
-pub(crate) fn resolve_git_ref(clone_dir: &Path, ref_id: &str, uri: &Url) -> Result<String, GitError> {
-    let output = process::Command::new("git")
-        .current_dir(clone_dir)
-        .args(["rev-parse", ref_id])
-        .output()?;
+async fn fetch(repo: &gitwrap::Repository, pb: &ProgressBar) -> Result<(), gitwrap::Error> {
+    let cb = set_progress_bar_style(pb);
 
-    if !output.status.success() {
-        return Err(GitError::UnresolvedRef {
-            ref_id: ref_id.to_owned(),
-            uri: uri.clone(),
-        });
-    }
+    let result = repo.fetch_progress(cb).await;
+    pb.finish_and_clear();
 
-    let stdout = String::from_utf8(output.stdout)?;
-    let parsed_hash = stdout.trim();
-
-    if !is_valid_commit_hash(parsed_hash) {
-        return Err(GitError::UnresolvedRef {
-            ref_id: ref_id.to_owned(),
-            uri: uri.clone(),
-        });
-    }
-
-    Ok(parsed_hash.to_owned())
+    result
 }
 
-/// Process git upstreams after cloning and return updated YAML if refs differ from resolved hashes.
-pub(crate) fn update_git_upstream_refs(
-    recipe_source: &str,
-    stored_upstreams: &[Stored],
-) -> Result<Option<String>, GitError> {
-    let mut yaml_updater = yaml::Updater::new();
-    let mut refs_updated = false;
+fn set_progress_bar_style(pb: &ProgressBar) -> impl Fn(gitwrap::FetchProgress) {
+    use tui::HumanBytes;
 
-    for stored in stored_upstreams.iter() {
-        if let Stored::Git(git) = stored
-            && git.resolved_hash != git.original_ref
-        {
-            update_git_upstream_ref_in_yaml(
-                &mut yaml_updater,
-                git.original_index,
-                git.uri.as_str(),
-                &git.resolved_hash,
-                &git.original_ref,
-            );
-            println!(
-                "{} | Updated ref '{}' to commit {} for {}",
-                "Warning".yellow(),
-                &git.resolved_hash[..8],
-                &git.original_ref,
-                &git.uri
-            );
-            refs_updated = true;
-        }
-    }
+    pb.set_length(100);
+    pb.set_style(
+        ProgressStyle::with_template("{prefix}\n|{bar:20.cyan/bue}| {percent}% {msg:>.dim}")
+            .unwrap()
+            .progress_chars("■≡=- "),
+    );
 
-    if refs_updated {
-        Ok(Some(yaml_updater.apply(recipe_source)))
-    } else {
-        Ok(None)
-    }
-}
-
-fn is_valid_commit_hash(s: &str) -> bool {
-    // git commit hashes can be SHA-1 or SHA-256 hashes
-    (s.len() == 40 || s.len() == 64) && s.chars().all(|c| c.is_ascii_hexdigit())
-}
-
-/// Replaces the non-hash refs for git upstreams with the hash for the given ref
-/// and includes a comment showing the original ref.
-fn update_git_upstream_ref_in_yaml(
-    updater: &mut yaml::Updater,
-    upstream_index: usize,
-    uri: &str,
-    new_ref: &str,
-    original_ref: &str,
-) {
-    let git_key = format!("git|{uri}");
-    let new_value_with_comment = format!("{new_ref} # {original_ref}");
-
-    // git|uri: <ref>
-    updater.update_value(&new_value_with_comment, |p| {
-        p / "upstreams" / upstream_index / git_key.as_str()
-    });
-
-    // git|uri:
-    // - ref: <ref>
-    // ...
-    updater.update_value(&new_value_with_comment, |p| {
-        p / "upstreams" / upstream_index / git_key.as_str() / "ref"
-    });
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::upstream::StoredGit;
-    use crate::upstream::plain::StoredPlain;
-
-    use super::*;
-    use fs_err as fs;
-    use std::process::Command;
-    use tempfile::TempDir;
-
-    #[test]
-    fn test_update_git_upstream_refs() {
-        let recipe_source = r#"
-upstreams:
-  - git|https://github.com/example/repo1.git: main
-  - git|https://github.com/example/repo2.git:
-      ref: main
-  - git|https://github.com/example/repo3.git: abcd1234567890abcdef1234567890abcdef1234
-  - git|https://github.com/example/repo4.git: abc123d
-  - https://example.com/file.tar.gz: some-hash
-"#;
-
-        let stored = vec![
-            Stored::Git(StoredGit {
-                name: "repo1.git".to_owned(),
-                path: "/tmp/repo1".into(),
-                was_cached: false,
-                uri: Url::parse("https://github.com/example/repo1.git").unwrap(),
-                original_ref: "main".to_owned(),
-                resolved_hash: "1111222233334444555566667777888899990000".to_owned(),
-                original_index: 0,
-            }),
-            Stored::Git(StoredGit {
-                name: "repo2.git".to_owned(),
-                path: "/tmp/repo2".into(),
-                was_cached: false,
-                uri: Url::parse("https://github.com/example/repo2.git").unwrap(),
-                original_ref: "main".to_owned(),
-                resolved_hash: "aaaa1111bbbb2222cccc3333dddd4444eeee5555".to_owned(),
-                original_index: 1,
-            }),
-            Stored::Git(StoredGit {
-                name: "repo3.git".to_owned(),
-                path: "/tmp/repo3".into(),
-                was_cached: false,
-                uri: Url::parse("https://github.com/example/repo3.git").unwrap(),
-                original_ref: "abcd1234567890abcdef1234567890abcdef1234".to_owned(),
-                resolved_hash: "abcd1234567890abcdef1234567890abcdef1234".to_owned(),
-                original_index: 2,
-            }),
-            Stored::Git(StoredGit {
-                name: "repo4.git".to_owned(),
-                path: "/tmp/repo4".into(),
-                was_cached: false,
-                uri: Url::parse("https://github.com/example/repo4.git").unwrap(),
-                original_ref: "abc123d".to_owned(),
-                resolved_hash: "abc123d567890abcdef1234567890abcdef12345".to_owned(),
-                original_index: 3,
-            }),
-            Stored::Git(StoredGit {
-                name: "file.tar.gz".to_owned(),
-                path: "/tmp/file.tar.gz".into(),
-                was_cached: false,
-                // We don't care about the values below.
-                uri: "http://example.com".try_into().unwrap(),
-                original_ref: String::new(),
-                resolved_hash: String::new(),
-                original_index: 0,
-            }),
-        ];
-
-        let result = update_git_upstream_refs(recipe_source, &stored).unwrap();
-
-        assert!(result.is_some());
-        let updated_yaml = result.unwrap();
-
-        // Should update short form ref to hash with comment
-        assert!(updated_yaml.contains("1111222233334444555566667777888899990000 # main"));
-
-        // Should update long form ref to hash with comment
-        assert!(updated_yaml.contains("aaaa1111bbbb2222cccc3333dddd4444eeee5555 # main"));
-
-        // Should not change hash that's already a hash
-        assert!(updated_yaml.contains("abcd1234567890abcdef1234567890abcdef1234"));
-        assert!(
-            !updated_yaml
-                .contains("abcd1234567890abcdef1234567890abcdef1234 # abcd1234567890abcdef1234567890abcdef1234")
-        );
-
-        // Should update short hash to long hash
-        assert!(updated_yaml.contains("abc123d567890abcdef1234567890abcdef12345 # abc123d"));
-
-        // Should preserve non-git upstreams unchanged
-        assert!(updated_yaml.contains("https://example.com/file.tar.gz: some-hash"));
-    }
-
-    #[test]
-    fn test_update_git_upstream_refs_no_updates() {
-        let recipe_source = r#"
-upstreams:
-  - git|https://github.com/example/repo3.git: abcd1234567890abcdef1234567890abcdef1234
-  - https://example.com/file.tar.gz: some-hash
-"#;
-
-        let stored = vec![
-            Stored::Git(StoredGit {
-                name: "repo3.git".to_owned(),
-                path: "/tmp/repo3".into(),
-                was_cached: false,
-                uri: Url::parse("https://github.com/example/repo3.git").unwrap(),
-                original_ref: "abcd1234567890abcdef1234567890abcdef1234".to_owned(),
-                resolved_hash: "abcd1234567890abcdef1234567890abcdef1234".to_owned(),
-                original_index: 0,
-            }),
-            Stored::Plain(StoredPlain {
-                name: "file.tar.gz".to_owned(),
-                path: "/tmp/file.tar.gz".into(),
-                was_cached: false,
-            }),
-        ];
-
-        let result = update_git_upstream_refs(recipe_source, &stored).unwrap();
-
-        assert!(result.is_none());
-    }
-
-    // Create a minimal test repo
-    fn setup_test_repo() -> (TempDir, String) {
-        let temp_dir = TempDir::new().unwrap();
-
-        // Initialize the repo
-        Command::new("git")
-            .current_dir(temp_dir.path())
-            .args(["init"])
-            .output()
-            .unwrap();
-        Command::new("git")
-            .current_dir(temp_dir.path())
-            .args(["config", "user.email", "test@test.com"])
-            .output()
-            .unwrap();
-        Command::new("git")
-            .current_dir(temp_dir.path())
-            .args(["config", "user.name", "Test"])
-            .output()
-            .unwrap();
-
-        // Create the first commit
-        fs::write(temp_dir.path().join("file"), "content").unwrap();
-        Command::new("git")
-            .current_dir(temp_dir.path())
-            .args(["add", "."])
-            .output()
-            .unwrap();
-        Command::new("git")
-            .current_dir(temp_dir.path())
-            .args(["commit", "-m", "test"])
-            .output()
-            .unwrap();
-
-        // Create a tag for testing
-        Command::new("git")
-            .current_dir(temp_dir.path())
-            .args(["tag", "v1.0"])
-            .output()
-            .unwrap();
-
-        // Get the commit hash for testing
-        let output = Command::new("git")
-            .current_dir(temp_dir.path())
-            .args(["rev-parse", "HEAD"])
-            .output()
-            .unwrap();
-        let commit_hash = String::from_utf8(output.stdout).unwrap().trim().to_owned();
-
-        (temp_dir, commit_hash)
-    }
-
-    #[test]
-    fn test_resolve_invalid_repo_path() {
-        let uri = Url::parse("https://example.com/test.git").unwrap();
-
-        let err = resolve_git_ref(Path::new("/nonexistent"), "v1.0", &uri).unwrap_err();
-
-        assert!(matches!(err, GitError::Io(_)));
-    }
-
-    #[test]
-    fn test_resolve_tag() {
-        let (temp_dir, expected_hash) = setup_test_repo();
-        let uri = Url::parse("https://example.com/test.git").unwrap();
-
-        let result = resolve_git_ref(temp_dir.path(), "v1.0", &uri).unwrap();
-
-        assert_eq!(result, expected_hash);
-    }
-
-    #[test]
-    fn test_resolve_short_hash() {
-        let (temp_dir, full_hash) = setup_test_repo();
-        let uri = Url::parse("https://example.com/test.git").unwrap();
-        let short_hash = &full_hash[..8];
-
-        let result = resolve_git_ref(temp_dir.path(), short_hash, &uri).unwrap();
-
-        assert_eq!(result, full_hash);
-    }
-
-    #[test]
-    fn test_resolve_full_hash() {
-        let (temp_dir, full_hash) = setup_test_repo();
-        let uri = Url::parse("https://example.com/test.git").unwrap();
-
-        let result = resolve_git_ref(temp_dir.path(), &full_hash, &uri).unwrap();
-
-        assert_eq!(result, full_hash);
-    }
-
-    #[test]
-    fn test_resolve_invalid_ref() {
-        let (temp_dir, _) = setup_test_repo();
-        let uri = Url::parse("https://example.com/test.git").unwrap();
-
-        let err = resolve_git_ref(temp_dir.path(), "nonexistent", &uri).unwrap_err();
-
-        assert!(matches!(err, GitError::UnresolvedRef { .. }));
+    |prog| {
+        pb.set_position(prog.percent as u64);
+        pb.set_message(format!("{}/s", HumanBytes(prog.speed)));
     }
 }

--- a/boulder/src/upstream/git.rs
+++ b/boulder/src/upstream/git.rs
@@ -141,7 +141,7 @@ pub struct StoredGit {
 
 impl StoredGit {
     /// Shares the Git repository in preparation of a build.
-    pub async fn share(&self, dest_dir: &Path) -> Result<SharedGit, Error> {
+    pub async fn share(&self, dest_dir: &Path) -> Result<(), Error> {
         if let Some(parent) = dest_dir.parent() {
             fs::create_dir_all(parent)?;
         }
@@ -157,18 +157,7 @@ impl StoredGit {
         // Finally checkout the desired commit
         cloned.checkout(&self.resolved_hash).await?;
 
-        Ok(SharedGit(dest_dir.to_owned()))
-    }
-}
-
-/// A shared Git repository is a copy of a stored Git
-/// in a location useful for a build.
-pub struct SharedGit(PathBuf);
-
-impl SharedGit {
-    /// Removes the shared Git repository.
-    pub fn remove(&self) -> Result<(), Error> {
-        fs::remove_dir_all(&self.0).map_err(Error::from)
+        Ok(())
     }
 }
 

--- a/boulder/src/upstream/plain.rs
+++ b/boulder/src/upstream/plain.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
+use std::ops::Deref;
 use std::{
     io,
     path::{Path, PathBuf},
@@ -9,35 +10,27 @@ use std::{
 };
 
 use fs_err as fs;
-use moss::{request, runtime, util};
+use moss::{request, util};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 use tui::{ProgressBar, ProgressStyle};
 use url::Url;
 
-use crate::Paths;
-
+/// Upstream based on an archive (typically a tarball).
 #[derive(Debug, Clone)]
 pub struct Plain {
+    /// URL from where the source archive is fetched.
     pub url: Url,
+    /// SHA256 hash of the archive.
     pub hash: Hash,
+    /// Name of the upstream when stored in the storage
+    /// directory. If None, a default name is implied from [Self::url].
     pub rename: Option<String>,
 }
 
 impl Plain {
-    pub async fn _fetch_new(url: Url, dest_file: &Path) -> Result<Self, Error> {
-        Self::_fetch_new_progress(url, dest_file, &ProgressBar::hidden()).await
-    }
-
-    pub async fn _fetch_new_progress(url: Url, dest_file: &Path, pb: &ProgressBar) -> Result<Self, Error> {
-        let hash = Self::fetch(&url, dest_file, pb).await?;
-        Ok(Self {
-            url,
-            hash,
-            rename: None,
-        })
-    }
-
+    /// Returns the name of the source archive.
+    /// If [Self::rename] is not defined, it is implied from the URL.
     pub fn name(&self) -> &str {
         if let Some(name) = &self.rename {
             name
@@ -46,108 +39,154 @@ impl Plain {
         }
     }
 
-    fn path(&self, paths: &Paths) -> PathBuf {
-        // Hash uri and file hash together
-        // for a unique file path that can
-        // be used for caching purposes and
-        // is busted if either uri or hash
-        // change
-        let mut hasher = Sha256::new();
-        hasher.update(self.url.as_str());
-        hasher.update(&self.hash.0);
-
-        let hash = hex::encode(hasher.finalize());
-
-        paths
-            .upstreams()
-            .host
-            .join("fetched")
-            // Type safe guaranteed to be >= 5 bytes
-            .join(&hash[..5])
-            .join(&hash[hash.len() - 5..])
-            .join(hash)
-    }
-
-    async fn fetch(url: &Url, dest_file: &Path, pb: &ProgressBar) -> Result<Hash, Error> {
-        pb.set_style(
-            ProgressStyle::with_template(" {spinner} {wide_msg} {binary_bytes_per_sec:>.dim} ")
-                .unwrap()
-                .tick_chars("--=≡■≡=--"),
-        );
-
-        let hash = request::download_with_progress_and_sha256(url.clone(), dest_file, |progress| {
-            pb.inc(progress.delta);
-        })
-        .await?;
-
-        Ok(hash.try_into()?)
-    }
-
-    pub async fn store(&self, paths: &Paths, pb: &ProgressBar) -> Result<StoredPlain, Error> {
+    /// Stores the source archive into the storage directory.
+    ///
+    /// If the upstream was already stored and [Self::hash] matches,
+    /// no write operation takes place. If the source archive was
+    /// not stored or the hash does not match, it is overwritten.
+    pub async fn store(&self, storage_dir: &Path, pb: &ProgressBar) -> Result<StoredPlain, Error> {
         use fs_err::tokio as fs;
 
-        pb.set_style(
-            ProgressStyle::with_template(" {spinner} {wide_msg} {binary_bytes_per_sec:>.dim} ")
-                .unwrap()
-                .tick_chars("--=≡■≡=--"),
-        );
-
-        let name = self.name();
-        let path = self.path(paths);
-        let partial_path = path.with_extension("part");
-
-        if let Some(parent) = path.parent().map(Path::to_path_buf) {
-            runtime::unblock(move || util::ensure_dir_exists(&parent)).await?;
+        match self.stored(storage_dir) {
+            Ok(stored) => return Ok(stored),
+            Err(Error::Io(e)) if e.kind() == io::ErrorKind::NotFound => {}
+            Err(Error::HashMismatch { .. }) => {}
+            Err(err) => return Err(err),
         }
 
-        if path.exists() {
-            return Ok(StoredPlain {
-                name: name.to_owned(),
-                path,
-                was_cached: true,
-            });
+        let path = self.stored_path(storage_dir);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(&parent).await?;
         }
 
-        let hash = Self::fetch(&self.url, &partial_path, pb).await?;
+        let hash = fetch(self.url.clone(), &path, pb).await?;
         if hash != self.hash {
-            fs::remove_file(&partial_path).await?;
+            fs::remove_file(&path).await?;
 
             return Err(Error::HashMismatch {
-                name: name.to_owned(),
-                expected: self.hash.0.clone(),
+                name: self.name().to_owned(),
+                expected: self.hash.to_string(),
                 got: hash,
             });
         }
 
-        fs::rename(partial_path, &path).await?;
-
         Ok(StoredPlain {
-            name: name.to_owned(),
+            name: self.name().to_owned(),
             path,
             was_cached: false,
         })
     }
 
-    pub fn remove(&self, paths: &Paths) -> Result<(), Error> {
-        let path = self.path(paths);
+    /// Unconditionally removes the source archive, and the parent
+    /// directories if they are empty, within the storage directory.
+    /// If the source archive does not exist, this function returns
+    /// successfully (it is idempotent).
+    ///
+    /// Careful: this function does not validate the archive!
+    /// It will be removed even if it does not belong to this Upstream.
+    pub fn remove(&self, storage_dir: &Path) -> Result<(), Error> {
+        let dir = self.stored_path(storage_dir);
 
-        fs::remove_file(&path)?;
+        fs::remove_file(&dir)?;
+        if let Some(parent) = dir.parent() {
+            Ok(util::remove_empty_dirs(parent, storage_dir)?)
+        } else {
+            Ok(())
+        }
+    }
 
-        if let Some(parent) = path.parent() {
-            util::remove_empty_dirs(parent, &paths.upstreams().host)?;
+    /// Returns an already-stored source archive.
+    /// An error is instead returned if the source archive is
+    /// not found in the storage directory, or its hash doesn't match
+    /// [Self::hash].
+    pub fn stored(&self, storage_dir: &Path) -> Result<StoredPlain, Error> {
+        let path = self.stored_path(storage_dir);
+
+        let mut file = fs_err::File::open(&path)?;
+        let hash = util::sha256_hash(&mut file)?;
+        if hash != self.hash.deref() {
+            return Err(Error::HashMismatch {
+                name: self.name().to_owned(),
+                expected: self.hash.to_string(),
+                got: Hash(hash),
+            });
         }
 
-        Ok(())
+        Ok(StoredPlain {
+            name: self.name().to_owned(),
+            path,
+            was_cached: true,
+        })
+    }
+
+    /// Returns a relative PathBuf where this source archive
+    /// should be stored within the storage directory.
+    fn stored_path(&self, storage_dir: &Path) -> PathBuf {
+        storage_dir.join(self.file_path())
+    }
+
+    /// Returns a relative PathBuf based on the hashes of [Self::url]
+    /// and [Self::hash].
+    ///
+    /// Hashing both ensures the path is unique and becomes invalid
+    /// as soon as either the URL or the hash changes.
+    fn file_path(&self) -> PathBuf {
+        let mut hasher = Sha256::new();
+        hasher.update(self.url.as_str());
+        hasher.update(self.hash.as_bytes());
+
+        let hash = hex::encode(hasher.finalize());
+        // Type safe guaranteed to be >= 5 bytes.
+        [&hash[..5], &hash[hash.len() - 5..], &hash].iter().collect()
     }
 }
 
+/// Information available after [Plain] is stored on disk.
 #[derive(Clone)]
 pub struct StoredPlain {
+    /// Name of the upstream, as returned by [Plain::name].
     pub name: String,
+    /// Path of the source archive after it was stored.
     pub path: PathBuf,
+    /// Whether the source archived was already stored with valid hash.
     pub was_cached: bool,
 }
 
+impl StoredPlain {
+    /// Shares the Git repository in preparation of a build.
+    ///
+    /// This function tries to be as efficient as possible in terms
+    /// of actual bytes copied: a hard link is created if possible.
+    pub fn share(&self, dest_dir: &Path) -> Result<SharedPlain, Error> {
+        let target = dest_dir.join(self.name.clone());
+
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        util::hardlink_or_copy(&self.path, &target)?;
+
+        Ok(SharedPlain { path: target })
+    }
+}
+
+/// A shared source archive is a copy of a stored source archive
+/// in a location useful for a build.
+pub struct SharedPlain {
+    /// Path of the source archive after it was shared.
+    pub path: PathBuf,
+}
+
+impl SharedPlain {
+    /// Removes the shared source archive.
+    /// Should the archive no longer exist,
+    /// this function returns successfully (it is idempotent).
+    pub fn remove(&self) -> Result<(), Error> {
+        fs::remove_file(&self.path).map_err(Error::from)
+    }
+}
+
+/// Thin wrapper around String that represents a
+/// hexadecimal SHA256 hash.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Hash(String);
 
@@ -167,24 +206,55 @@ impl TryFrom<String> for Hash {
     type Error = ParseHashError;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        Self::from_str(value.as_str())
+        if value.len() < 5 {
+            return Err(ParseHashError::TooShort(value));
+        }
+        Ok(Self(value))
     }
 }
 
+impl Deref for Hash {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_str()
+    }
+}
+
+/// Reasons why [Hash] may be invalid.
 #[derive(Debug, Error)]
 pub enum ParseHashError {
     #[error("hash too short: {0}")]
     TooShort(String),
 }
 
+/// Possible errors returned by functions in this module.
 #[derive(Debug, Error)]
 pub enum Error {
+    /// [Hash] is malformed.
     #[error("parse hash")]
     ParseHash(#[from] ParseHashError),
+    /// Two hashes did not match.
     #[error("hash mismatch for {name}, expected {expected:?} got {:?}", got.0)]
     HashMismatch { name: String, expected: String, got: Hash },
     #[error("request")]
+    /// A local or remote fetch failed.
     Request(#[from] request::Error),
     #[error("io")]
+    /// A generic I/O error occurred.
     Io(#[from] io::Error),
+}
+
+async fn fetch(url: Url, dest: &Path, pb: &ProgressBar) -> Result<Hash, Error> {
+    pb.set_style(
+        ProgressStyle::with_template(" {spinner} {wide_msg} {binary_bytes_per_sec:>.dim} ")
+            .unwrap()
+            .tick_chars("--=≡■≡=--"),
+    );
+
+    request::download_with_progress_and_sha256(url, dest, |progress| pb.inc(progress.delta))
+        .await
+        .map_err(Error::from)?
+        .try_into()
+        .map_err(Error::from)
 }

--- a/boulder/src/upstream/plain.rs
+++ b/boulder/src/upstream/plain.rs
@@ -122,7 +122,7 @@ impl Plain {
     /// Returns a relative PathBuf where this source archive
     /// should be stored within the storage directory.
     fn stored_path(&self, storage_dir: &Path) -> PathBuf {
-        storage_dir.join(self.file_path())
+        storage_dir.join("fetched").join(self.file_path())
     }
 
     /// Returns a relative PathBuf based on the hashes of [Self::url]

--- a/boulder/src/upstream/plain.rs
+++ b/boulder/src/upstream/plain.rs
@@ -157,7 +157,7 @@ impl StoredPlain {
     ///
     /// This function tries to be as efficient as possible in terms
     /// of actual bytes copied: a hard link is created if possible.
-    pub fn share(&self, dest_dir: &Path) -> Result<SharedPlain, Error> {
+    pub fn share(&self, dest_dir: &Path) -> Result<(), Error> {
         let target = dest_dir.join(self.name.clone());
 
         if let Some(parent) = target.parent() {
@@ -165,23 +165,7 @@ impl StoredPlain {
         }
         util::hardlink_or_copy(&self.path, &target)?;
 
-        Ok(SharedPlain { path: target })
-    }
-}
-
-/// A shared source archive is a copy of a stored source archive
-/// in a location useful for a build.
-pub struct SharedPlain {
-    /// Path of the source archive after it was shared.
-    pub path: PathBuf,
-}
-
-impl SharedPlain {
-    /// Removes the shared source archive.
-    /// Should the archive no longer exist,
-    /// this function returns successfully (it is idempotent).
-    pub fn remove(&self) -> Result<(), Error> {
-        fs::remove_file(&self.path).map_err(Error::from)
+        Ok(())
     }
 }
 

--- a/crates/gitwrap/Cargo.toml
+++ b/crates/gitwrap/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "gitwrap"
+edition = "2021"
+version.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+thiserror.workspace = true
+tokio.workspace = true
+url.workspace = true
+
+[lints]
+workspace = true

--- a/crates/gitwrap/src/error.rs
+++ b/crates/gitwrap/src/error.rs
@@ -40,8 +40,6 @@ impl Error {
 pub enum Constraint {
     /// The repository is valid, but it is not bare.
     NotBare,
-    /// The commit is not identified by its hash.
-    NotPeeled { commit: String },
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -63,7 +61,6 @@ impl fmt::Display for Constraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::NotBare => write!(f, "this repository is not bare"),
-            Self::NotPeeled { commit } => write!(f, "commit ID \"{commit}\" is not a commit hash"),
         }
     }
 }

--- a/crates/gitwrap/src/error.rs
+++ b/crates/gitwrap/src/error.rs
@@ -1,0 +1,85 @@
+use std::{fmt, io};
+
+/// The error type for operations using the `git` executable.
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct Error(#[from] InnerError);
+
+impl Error {
+    /// Returns the kind of I/O error if such error happened.
+    /// Otherwise, it returns [None].
+    ///
+    /// Any I/O error is related to calling the `git` executable.
+    /// Refer to [Self::run_failed] for I/O errors that occurred within
+    /// `git`'s execution.
+    pub fn io_kind(&self) -> Option<io::ErrorKind> {
+        if let InnerError::Io(err) = &self.0 {
+            Some(err.kind())
+        } else {
+            None
+        }
+    }
+
+    /// Returns whether `git` exited with an error code.
+    pub fn run_failed(&self) -> bool {
+        matches!(self.0, InnerError::Run { .. })
+    }
+
+    /// Returns the kind of violated [Constraint] if such error happened.
+    /// Otherwise, it returns [None].
+    pub fn constraint(&self) -> Option<&Constraint> {
+        if let InnerError::Constraint(con) = &self.0 {
+            Some(con)
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Constraint {
+    /// The repository is valid, but it is not bare.
+    NotBare,
+    /// The commit is not identified by its hash.
+    NotPeeled { commit: String },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum InnerError {
+    /// A generic I/O error occurred.
+    #[error(transparent)]
+    Io(#[from] io::Error),
+
+    /// The `git` executable returned with an error.
+    /// A dump of the stderr may be provided.
+    #[error("{}", display_run(code, stderr))]
+    Run { code: Option<i32>, stderr: Option<String> },
+
+    #[error(transparent)]
+    Constraint(#[from] Constraint),
+}
+
+impl fmt::Display for Constraint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotBare => write!(f, "this repository is not bare"),
+            Self::NotPeeled { commit } => write!(f, "commit ID \"{commit}\" is not a commit hash"),
+        }
+    }
+}
+
+fn display_run(code: &Option<i32>, stderr: &Option<String>) -> String {
+    let mut string = String::from("`git` exited ");
+
+    if let Some(code) = code {
+        string.push_str(&format!("with code {code}"));
+    } else {
+        string.push_str("unexpectedly");
+    }
+
+    if let Some(msg) = stderr {
+        string.push_str(&format!(". Diagnostic output below:\n{msg}"));
+    }
+
+    string
+}

--- a/crates/gitwrap/src/lib.rs
+++ b/crates/gitwrap/src/lib.rs
@@ -95,6 +95,45 @@ impl Repository {
         Ok(output.stdout.starts_with(b"commit"))
     }
 
+    /// Returns the remote URL for the provided `remote`
+    pub async fn get_remote_url(&self, remote: &str) -> Result<String, Error> {
+        let output = run_git(&[
+            OsStr::new("-C"),
+            self.path.as_os_str(),
+            OsStr::new("remote"),
+            OsStr::new("get-url"),
+            OsStr::new(remote),
+        ])
+        .await?;
+        Ok(str::from_utf8(&output.stdout).unwrap_or("").to_owned())
+    }
+
+    /// Sets the remote URL for the provided `remote` to `url`
+    pub async fn set_remote_url(&self, remote: &str, url: &str) -> Result<(), Error> {
+        run_git(&[
+            OsStr::new("-C"),
+            self.path.as_os_str(),
+            OsStr::new("remote"),
+            OsStr::new("set-url"),
+            OsStr::new(remote),
+            OsStr::new(url),
+        ])
+        .await?;
+        Ok(())
+    }
+
+    /// Checkout the provided `rev` (branch or commit)
+    pub async fn checkout(&self, rev: &str) -> Result<(), Error> {
+        run_git(&[
+            OsStr::new("-C"),
+            self.path.as_os_str(),
+            OsStr::new("checkout"),
+            OsStr::new(rev),
+        ])
+        .await?;
+        Ok(())
+    }
+
     /// Equivalent to `git fetch`.
     /// A callback is fired repeatedly to track the fetching
     /// process in real time.
@@ -115,93 +154,19 @@ impl Repository {
         Ok(())
     }
 
-    /// Add a new Git worktree at `path`.
-    ///
-    /// The worktree is checked out at the provided commit.
-    /// If a worktree already exists at `path`, is it overwritten.
-    ///
-    /// This function expects a "peeled" commit hash. If a reference
-    /// (e.g. a tag) is passed, an error containing [Constraint::NotPeeled] is returned.
-    /// This ensures the worktree is created with predictable content,
-    /// since a reference may change the commit it points to over time.
-    pub async fn add_worktree(&self, path: &Path, commit: &str) -> Result<Worktree, Error> {
-        if commit.starts_with("HEAD") {
-            return Err(InnerError::Constraint(Constraint::NotPeeled {
-                commit: commit.to_owned(),
-            }))?;
-        }
-
+    /// Clone the current [`Repository`] to the provided `path` and return
+    /// the cloned to [`Repository`].
+    pub async fn clone_to(&self, path: &Path) -> Result<Self, Error> {
         let path = path::absolute(path).map_err(InnerError::from)?;
 
-        let output = run_git(&[
-            OsStr::new("-C"),
-            self.path.as_os_str(),
-            OsStr::new("cat-file"),
-            OsStr::new("-t"),
-            OsStr::new(commit),
-        ])
-        .await?;
-        if !output.stdout.starts_with(b"commit") {
-            return Err(InnerError::Constraint(Constraint::NotPeeled {
-                commit: commit.to_owned(),
-            }))?;
-        }
+        // Clone it to `path`
+        run_git(&[OsStr::new("clone"), self.path.as_os_str(), path.as_os_str()]).await?;
 
-        run_git(&[
-            OsStr::new("-C"),
-            self.path.as_os_str(),
-            OsStr::new("worktree"),
-            OsStr::new("add"),
-            OsStr::new("-f"), // Pass double force to overwrite possible locked worktrees.
-            OsStr::new("-f"),
-            path.as_os_str(),
-            OsStr::new(commit),
-        ])
-        .await?;
-        Ok(Worktree {
-            repo: self.path.clone(),
-            worktree: path,
-        })
+        Ok(Self { path: path.to_owned() })
     }
 
     pub fn path(&self) -> &Path {
         &self.path
-    }
-}
-
-/// A Git worktree.
-pub struct Worktree {
-    repo: PathBuf,
-    worktree: PathBuf,
-}
-
-impl Worktree {
-    /// Removes the worktree.
-    /// This means removing the actual directory
-    /// containing the worktree, and untracking
-    /// the worktree from the Git repository.
-    pub async fn remove(&self) -> Result<(), Error> {
-        run_git([
-            OsStr::new("-C"),
-            self.repo.as_os_str(),
-            OsStr::new("worktree"),
-            OsStr::new("remove"),
-            self.worktree.as_os_str(),
-        ])
-        .await
-        .map(|_| ())
-    }
-
-    /// Synchronous version of [Self::remove].
-    pub fn remove_sync(&self) -> Result<(), Error> {
-        run_git_sync([
-            OsStr::new("-C"),
-            self.repo.as_os_str(),
-            OsStr::new("worktree"),
-            OsStr::new("remove"),
-            self.worktree.as_os_str(),
-        ])
-        .map(|_| ())
     }
 }
 
@@ -225,28 +190,6 @@ where
         .stdin(Stdio::null())
         .output()
         .await
-        .map_err(InnerError::from)?;
-    if output.status.success() {
-        Ok(output)
-    } else {
-        Err(InnerError::Run {
-            code: output.status.code(),
-            stderr: Some(String::from_utf8(output.stderr).unwrap()),
-        })?
-    }
-}
-
-/// Runs git and waits for it to terminate.
-/// It's the synchronous version of [run_git].
-fn run_git_sync<I, S>(args: I) -> Result<std::process::Output, Error>
-where
-    I: IntoIterator<Item = S>,
-    S: AsRef<OsStr>,
-{
-    let output = std::process::Command::new("git")
-        .args(args)
-        .stdin(Stdio::null())
-        .output()
         .map_err(InnerError::from)?;
     if output.status.success() {
         Ok(output)

--- a/crates/gitwrap/src/lib.rs
+++ b/crates/gitwrap/src/lib.rs
@@ -21,7 +21,9 @@ pub use self::error::Error;
 use error::{Constraint, InnerError};
 
 /// An uninitialized repository, useful for unit tests.
-pub const NULL_REPOSITORY: Repository = Repository { path: PathBuf::new() };
+pub fn null_repository() -> Repository {
+    Repository { path: PathBuf::new() }
+}
 
 /// A Git repository.
 pub struct Repository {

--- a/crates/gitwrap/src/lib.rs
+++ b/crates/gitwrap/src/lib.rs
@@ -20,6 +20,9 @@ pub mod error;
 pub use self::error::Error;
 use error::{Constraint, InnerError};
 
+/// An uninitialized repository, useful for unit tests.
+pub const NULL_REPOSITORY: Repository = Repository { path: PathBuf::new() };
+
 /// A Git repository.
 pub struct Repository {
     path: PathBuf,
@@ -93,6 +96,20 @@ impl Repository {
         ])
         .await?;
         Ok(output.stdout.starts_with(b"commit"))
+    }
+
+    /// Returns the hash of the commit. If a commit hash is passed,
+    /// the output is equal to `commit`. If a Git reference is passed, the
+    /// reference is resolved into a commit hash.
+    pub async fn peel_commit(&self, commit: &str) -> Result<String, Error> {
+        let output = run_git(&[
+            OsStr::new("-C"),
+            self.path.as_os_str(),
+            OsStr::new("rev-parse"),
+            OsStr::new(commit),
+        ])
+        .await?;
+        Ok(str::from_utf8(output.stdout.trim_ascii_end()).unwrap_or("").to_owned())
     }
 
     /// Returns the remote URL for the provided `remote`

--- a/crates/gitwrap/src/lib.rs
+++ b/crates/gitwrap/src/lib.rs
@@ -210,8 +210,8 @@ impl Worktree {
 pub struct FetchProgress {
     /// Completion percentage.
     pub percent: u8,
-    /// Download speed in bytes per second.
-    pub speed: u64,
+    /// Download speed in formatted human units per second
+    pub speed: String,
 }
 
 /// Runs git and waits for it to terminate.
@@ -327,35 +327,27 @@ impl<R: io::AsyncRead + Unpin> ProgressParser<R> {
                 continue;
             }
             let line = &str::from_utf8(&line[Self::PREFIX.len()..]).unwrap_or("");
-            callback(Self::parse_progress(line));
+            if let Some(progress) = Self::parse_progress(line) {
+                callback(progress);
+            }
         }
         Ok(())
     }
 
-    fn parse_progress(line: &str) -> FetchProgress {
+    fn parse_progress(line: &str) -> Option<FetchProgress> {
         let mut tokens = line.split_ascii_whitespace();
 
-        let percent = tokens
-            .by_ref()
-            .next()
-            .map_or("0", |tok| tok.strip_suffix("%").unwrap_or(tok));
-        let speed_unit = tokens
-            .by_ref()
-            .next_back()
-            .map_or("B", |tok| tok.strip_suffix("/s").unwrap_or(tok));
-        let speed = tokens.by_ref().next_back().unwrap_or("0");
+        let percent = tokens.next()?;
+        let unit_per_sec = tokens.next_back()?;
+        let speed = tokens.next_back()?;
 
-        FetchProgress {
-            percent: percent.parse().unwrap_or_default(),
-            speed: speed.parse::<f32>().unwrap_or_default().trunc() as u64
-                * match speed_unit {
-                    "B" => 1,
-                    "KiB" => 1 << 10,
-                    "MiB" => 1 << 20,
-                    "GiB" => 1 << 30,
-                    "TiB" => 1 << 40,
-                    _ => 1,
-                },
+        if !unit_per_sec.ends_with("/s") {
+            return None;
         }
+
+        Some(FetchProgress {
+            percent: percent.strip_suffix('%')?.parse().ok()?,
+            speed: format!("{speed} {unit_per_sec}"),
+        })
     }
 }

--- a/crates/gitwrap/src/lib.rs
+++ b/crates/gitwrap/src/lib.rs
@@ -1,0 +1,361 @@
+//! Git repository manipulation utilities based
+//! on the `git` executable.
+//!
+//! For any operation, `git` is called under the hood:
+//! make sure it is available in your `$PATH`, otherwise
+//! [Error] will be returned.
+//!
+//! Even though we are aware that calling executables is brittle API,
+//! neither libgit2 nor gitoxide had all operations available in this
+//! module implemented.
+
+use std::ffi::OsStr;
+use std::path::{self, Path, PathBuf};
+use std::process::Stdio;
+
+use tokio::{io, process};
+use url::Url;
+
+pub mod error;
+pub use self::error::Error;
+use error::{Constraint, InnerError};
+
+/// A Git repository.
+pub struct Repository {
+    path: PathBuf,
+}
+
+impl Repository {
+    /// Opens a local bare Git repository.
+    /// If the Git repository at `path` is not bare,
+    /// an [Error] containing [Constraint::NotBare] is returned.
+    pub async fn open_bare(path: &Path) -> Result<Self, Error> {
+        let path = path::absolute(path).map_err(InnerError::from)?;
+        let output = run_git(&[
+            OsStr::new("-C"),
+            path.as_os_str(),
+            OsStr::new("repo"),
+            OsStr::new("info"),
+            OsStr::new("layout.bare"),
+        ])
+        .await?;
+        if !output.stdout.starts_with(b"layout.bare=true") {
+            return Err(InnerError::Constraint(Constraint::NotBare))?;
+        }
+        Ok(Self { path })
+    }
+
+    /// Clones a local or remote Git repository as bare into `path`.
+    /// The clone is performed with Git's `--mirror` flag.
+    pub async fn clone_mirror(path: &Path, url: &Url) -> Result<Self, Error> {
+        let path = path::absolute(path).map_err(InnerError::from)?;
+        run_git(&[
+            OsStr::new("clone"),
+            OsStr::new("--mirror"),
+            OsStr::new(&url.as_str()),
+            path.as_os_str(),
+        ])
+        .await?;
+        Ok(Self { path })
+    }
+
+    /// Clones a local or remote Git repository as bare into `path`.
+    /// The clone is performed with Git's `--mirror` flag.
+    /// A callback is fired repeatedly to track the cloning
+    /// process in real time.
+    pub async fn clone_mirror_progress<F>(path: &Path, url: &Url, callback: F) -> Result<Self, Error>
+    where
+        F: Fn(FetchProgress),
+    {
+        let path = path::absolute(path).map_err(InnerError::from)?;
+        run_git_progress(
+            &[
+                OsStr::new("clone"),
+                OsStr::new("--mirror"),
+                OsStr::new("--progress"),
+                OsStr::new(&url.as_str()),
+                path.as_os_str(),
+            ],
+            callback,
+        )
+        .await?;
+        Ok(Self { path })
+    }
+
+    /// Whether this repository has a commit identified by its hash.
+    pub async fn has_commit(&self, commit: &str) -> Result<bool, Error> {
+        let output = run_git(&[
+            OsStr::new("-C"),
+            self.path.as_os_str(),
+            OsStr::new("cat-file"),
+            OsStr::new("-t"),
+            OsStr::new(commit),
+        ])
+        .await?;
+        Ok(output.stdout.starts_with(b"commit"))
+    }
+
+    /// Equivalent to `git fetch`.
+    /// A callback is fired repeatedly to track the fetching
+    /// process in real time.
+    pub async fn fetch_progress<F>(&self, callback: F) -> Result<(), Error>
+    where
+        F: Fn(FetchProgress),
+    {
+        run_git_progress(
+            &[
+                OsStr::new("-C"),
+                self.path.as_os_str(),
+                OsStr::new("fetch"),
+                OsStr::new("--progress"),
+            ],
+            callback,
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Add a new Git worktree at `path`.
+    ///
+    /// The worktree is checked out at the provided commit.
+    /// If a worktree already exists at `path`, is it overwritten.
+    ///
+    /// This function expects a "peeled" commit hash. If a reference
+    /// (e.g. a tag) is passed, an error containing [Constraint::NotPeeled] is returned.
+    /// This ensures the worktree is created with predictable content,
+    /// since a reference may change the commit it points to over time.
+    pub async fn add_worktree(&self, path: &Path, commit: &str) -> Result<Worktree, Error> {
+        if commit.starts_with("HEAD") {
+            return Err(InnerError::Constraint(Constraint::NotPeeled {
+                commit: commit.to_owned(),
+            }))?;
+        }
+
+        let path = path::absolute(path).map_err(InnerError::from)?;
+
+        let output = run_git(&[
+            OsStr::new("-C"),
+            self.path.as_os_str(),
+            OsStr::new("cat-file"),
+            OsStr::new("-t"),
+            OsStr::new(commit),
+        ])
+        .await?;
+        if !output.stdout.starts_with(b"commit") {
+            return Err(InnerError::Constraint(Constraint::NotPeeled {
+                commit: commit.to_owned(),
+            }))?;
+        }
+
+        run_git(&[
+            OsStr::new("-C"),
+            self.path.as_os_str(),
+            OsStr::new("worktree"),
+            OsStr::new("add"),
+            OsStr::new("-f"), // Pass double force to overwrite possible locked worktrees.
+            OsStr::new("-f"),
+            path.as_os_str(),
+            OsStr::new(commit),
+        ])
+        .await?;
+        Ok(Worktree {
+            repo: self.path.clone(),
+            worktree: path,
+        })
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+/// A Git worktree.
+pub struct Worktree {
+    repo: PathBuf,
+    worktree: PathBuf,
+}
+
+impl Worktree {
+    /// Removes the worktree.
+    /// This means removing the actual directory
+    /// containing the worktree, and untracking
+    /// the worktree from the Git repository.
+    pub async fn remove(&self) -> Result<(), Error> {
+        run_git([
+            OsStr::new("-C"),
+            self.repo.as_os_str(),
+            OsStr::new("worktree"),
+            OsStr::new("remove"),
+            self.worktree.as_os_str(),
+        ])
+        .await
+        .map(|_| ())
+    }
+
+    /// Synchronous version of [Self::remove].
+    pub fn remove_sync(&self) -> Result<(), Error> {
+        run_git_sync([
+            OsStr::new("-C"),
+            self.repo.as_os_str(),
+            OsStr::new("worktree"),
+            OsStr::new("remove"),
+            self.worktree.as_os_str(),
+        ])
+        .map(|_| ())
+    }
+}
+
+/// The argument of callbacks when they are invoked
+/// for reporting a Git operation's progress.
+pub struct FetchProgress {
+    /// Completion percentage.
+    pub percent: u8,
+    /// Download speed in bytes per second.
+    pub speed: u64,
+}
+
+/// Runs git and waits for it to terminate.
+async fn run_git<I, S>(args: I) -> Result<std::process::Output, Error>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let output = process::Command::new("git")
+        .args(args)
+        .stdin(Stdio::null())
+        .output()
+        .await
+        .map_err(InnerError::from)?;
+    if output.status.success() {
+        Ok(output)
+    } else {
+        Err(InnerError::Run {
+            code: output.status.code(),
+            stderr: Some(String::from_utf8(output.stderr).unwrap()),
+        })?
+    }
+}
+
+/// Runs git and waits for it to terminate.
+/// It's the synchronous version of [run_git].
+fn run_git_sync<I, S>(args: I) -> Result<std::process::Output, Error>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let output = std::process::Command::new("git")
+        .args(args)
+        .stdin(Stdio::null())
+        .output()
+        .map_err(InnerError::from)?;
+    if output.status.success() {
+        Ok(output)
+    } else {
+        Err(InnerError::Run {
+            code: output.status.code(),
+            stderr: Some(String::from_utf8(output.stderr).unwrap()),
+        })?
+    }
+}
+
+async fn run_git_progress<I, S, F>(args: I, callback: F) -> Result<(), Error>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+    F: Fn(FetchProgress),
+{
+    let (mut git, stderr) = spawn_git(args)?;
+
+    let parser = async move {
+        let prog = ProgressParser::new(stderr);
+        prog.parse(callback).await
+    };
+
+    let (_, result) = tokio::join!(parser, git.wait());
+    let result = result.map_err(InnerError::from)?;
+    if result.success() {
+        Ok(())
+    } else {
+        Err(InnerError::Run {
+            code: result.code(),
+            stderr: None,
+        })?
+    }
+}
+
+fn spawn_git<I, S>(args: I) -> Result<(process::Child, process::ChildStderr), Error>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let mut child = process::Command::new("git")
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(InnerError::from)?;
+    let stderr = child.stderr.take().unwrap();
+    Ok((child, stderr))
+}
+
+struct ProgressParser<R: io::AsyncRead> {
+    reader: io::BufReader<R>,
+}
+
+impl<R: io::AsyncRead + Unpin> ProgressParser<R> {
+    const TERMINATOR: u8 = b'\r';
+    const PREFIX: &[u8] = b"Receiving objects:";
+
+    pub fn new(stderr: R) -> Self {
+        Self {
+            reader: io::BufReader::new(stderr),
+        }
+    }
+
+    // We're parsing lines like:
+    // "Receiving objects:  26% (163045/627093), 52.57 MiB | 34.99 MiB/s"
+    // And we want the percentage and the speed, which are conveniently
+    // the first and the last tokens of the line.
+
+    pub async fn parse(self, callback: impl Fn(FetchProgress)) -> Result<(), Error> {
+        use tokio::io::AsyncBufReadExt;
+
+        let mut lines = self.reader.split(Self::TERMINATOR);
+        while let Some(line) = lines.next_segment().await.map_err(InnerError::from)? {
+            if !line.starts_with(Self::PREFIX) {
+                continue;
+            }
+            let line = &str::from_utf8(&line[Self::PREFIX.len()..]).unwrap_or("");
+            callback(Self::parse_progress(line));
+        }
+        Ok(())
+    }
+
+    fn parse_progress(line: &str) -> FetchProgress {
+        let mut tokens = line.split_ascii_whitespace();
+
+        let percent = tokens
+            .by_ref()
+            .next()
+            .map_or("0", |tok| tok.strip_suffix("%").unwrap_or(tok));
+        let speed_unit = tokens
+            .by_ref()
+            .next_back()
+            .map_or("B", |tok| tok.strip_suffix("/s").unwrap_or(tok));
+        let speed = tokens.by_ref().next_back().unwrap_or("0");
+
+        FetchProgress {
+            percent: percent.parse().unwrap_or_default(),
+            speed: speed.parse::<f32>().unwrap_or_default().trunc() as u64
+                * match speed_unit {
+                    "B" => 1,
+                    "KiB" => 1 << 10,
+                    "MiB" => 1 << 20,
+                    "GiB" => 1 << 30,
+                    "TiB" => 1 << 40,
+                    _ => 1,
+                },
+        }
+    }
+}

--- a/crates/stone_recipe/src/upstream.rs
+++ b/crates/stone_recipe/src/upstream.rs
@@ -14,7 +14,6 @@ pub static GIT_PREFIX: &str = "git|";
 #[derive(Debug, Clone)]
 pub struct Upstream {
     pub url: Url,
-    pub unpack_dir: Option<PathBuf>,
     pub props: Props,
 }
 
@@ -24,42 +23,30 @@ impl<'de> Deserialize<'de> for Upstream {
         D: serde::Deserializer<'de>,
     {
         #[derive(Debug, Deserialize)]
-        struct SerdeProps {
-            #[serde(rename = "unpackdir")]
-            unpack_dir: Option<PathBuf>,
-            #[serde(flatten)]
-            specific: Props,
-        }
-
-        #[derive(Debug, Deserialize)]
         #[serde(untagged)]
         enum Fields {
             String(String),
-            Props(SerdeProps),
+            Props(Props),
         }
 
         let (uri, fields) = BTreeMap::<SourceUri, Fields>::deserialize(deserializer)?
             .into_iter()
             .next()
             .ok_or(serde::de::Error::custom("no upstream"))?;
-        let (unpack_dir, props) = match fields {
+        let props = match fields {
             Fields::String(hash) => match &uri.kind {
-                Kind::Archive => (None, Props::default_plain(hash)),
-                Kind::Git => (None, Props::default_git(hash)),
+                Kind::Archive => Props::default_plain(hash),
+                Kind::Git => Props::default_git(hash),
             },
-            Fields::Props(props) => match (&props.specific, &uri.kind) {
+            Fields::Props(props) => match (&props, &uri.kind) {
                 (Props::Git { .. }, Kind::Archive) | (Props::Plain { .. }, Kind::Git) => {
                     return Err(serde::de::Error::custom("mismatched URL type and upstream properties"));
                 }
-                _ => (props.unpack_dir, props.specific),
+                _ => props,
             },
         };
 
-        Ok(Self {
-            url: uri.into(),
-            unpack_dir,
-            props,
-        })
+        Ok(Self { url: uri.into(), props })
     }
 }
 
@@ -151,12 +138,14 @@ pub enum Props {
         strip_dirs: Option<u8>,
         #[serde(default = "default_true", deserialize_with = "stringy_bool")]
         unpack: bool,
+        #[serde(rename = "unpackdir")]
+        unpack_dir: Option<PathBuf>,
     },
     Git {
         #[serde(rename = "ref")]
         git_ref: String,
-        #[serde(default = "default_true", deserialize_with = "stringy_bool")]
-        staging: bool,
+        #[serde(rename = "clonedir")]
+        clone_dir: Option<PathBuf>,
     },
 }
 
@@ -167,11 +156,15 @@ impl Props {
             rename: None,
             strip_dirs: None,
             unpack: true,
+            unpack_dir: None,
         }
     }
 
     fn default_git(git_ref: String) -> Self {
-        Self::Git { git_ref, staging: true }
+        Self::Git {
+            git_ref,
+            clone_dir: None,
+        }
     }
 }
 


### PR DESCRIPTION
This PR introduces the `gitwrap` crate to handle Git repositories from a centralized API. This crate calls the `git` executable under the hood. It's not ideal, but neither libgit2 nor gitoxide support all operations we need to perform (as of April 2026), particularly worktrees.

It also refactors the code for storing and *sharing*[1] plain and Git upstreams.\
With regards to storing, we are now storing repositories in Mirror mode, under directories with unique names composed of the host they were downloaded from, and the very repository's name, e.g. `invent.kde.org_qt.qt.qtdeclarative.git`.
With regards to sharing, we clone the stored repository into the destination directory, also copying the Git remotes from the original ("centralized") repository. This ensures Git sub-modules with relative paths are resolved against the original remote and not against our local mirror. This ensures the removal of our `staging` option, that was developed to work around Git submodules with relative paths.

This PR also restores the `clonedir` option, that I initially removed under assumptions that not shared by the rest of the Team.

[1] We call *sharing* the act of copying an upstream to a build directory when building a recipe. We try to perform such copy as efficiently as possible, e.g. by using hard links.

### Test plan

Recipes I successfully built:
- g/gexiv2/stone.yaml
- f/font-monaspace/stone.yaml
- n/nano/stone.yaml
- q/qt5-declarative/stone.yaml
 
I built all recipes twice, to check that the upstream is downloaded only once.

I also made sure that `%break_continue`, `%break_exit` and plain `boulder chroot` work.

---

This is a refactor. Code inside `boulder` should be reviewed per file, instead of per diff.