### PR TITLE
Add some error context to package analysis handlers

### DIFF
--- a/boulder/src/lib.rs
+++ b/boulder/src/lib.rs
@@ -21,3 +21,4 @@ pub mod profile;
 pub mod recipe;
 pub mod timing;
 pub mod upstream;
+mod util;

--- a/boulder/src/package/analysis/handler.rs
+++ b/boulder/src/package/analysis/handler.rs
@@ -10,7 +10,7 @@ use std::{
 use fs_err::{self as fs, File};
 use moss::{Dependency, Provider, dependency};
 
-use crate::package::collect::PathInfo;
+use crate::{package::collect::PathInfo, util::ResultExt as _};
 
 pub use self::elf::elf;
 pub use self::python::python;
@@ -99,8 +99,9 @@ pub fn pkg_config(bucket: &mut BucketMut<'_>, info: &mut PathInfo) -> Result<Res
                 },
             ),
         ])
-        .output()?;
-    let stdout = String::from_utf8(output.stdout)?;
+        .output()
+        .context("failed to run pkg-config")?;
+    let stdout = String::from_utf8(output.stdout).context("unexpected pkg-config output")?;
     let deps = stdout.lines().filter_map(|line| line.split_whitespace().next());
 
     for dep in deps {
@@ -213,14 +214,15 @@ pub fn compressman(bucket: &mut BucketMut<'_>, info: &mut PathInfo) -> Result<Re
             let _ = bucket.paths.install().guest.join(&compressed_zst_file);
         }
 
-        symlink(&compressed_zst_file, &new_zst_symlink)?;
+        symlink(&compressed_zst_file, &new_zst_symlink).context("creating zstd symlink")?;
 
         /* Restore the original {a,m}times for reproducibility */
         filetime::set_symlink_file_times(
             &new_zst_symlink,
             FileTime::from_system_time(atime),
             FileTime::from_system_time(mtime),
-        )?;
+        )
+        .context("updating symlink file times")?;
 
         generated_path.push(bucket.paths.install().guest.join(new_zst_symlink));
         return Ok(Decision::ReplaceFile {
@@ -239,7 +241,8 @@ pub fn compressman(bucket: &mut BucketMut<'_>, info: &mut PathInfo) -> Result<Re
         &File::open(&compressed_zst_file)?.into_file(),
         Some(FileTime::from_system_time(atime)),
         Some(FileTime::from_system_time(mtime)),
-    )?;
+    )
+    .context("updating zstd archive file times")?;
 
     generated_path.push(bucket.paths.install().guest.join(compressed_zst_file));
 

--- a/boulder/src/util.rs
+++ b/boulder/src/util.rs
@@ -1,0 +1,35 @@
+use std::{borrow::Cow, error::Error, fmt};
+
+#[derive(Debug)]
+pub(crate) struct ErrorWithContext<E> {
+    message: Cow<'static, str>,
+    error: E,
+}
+
+impl<E> fmt::Display for ErrorWithContext<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl<E: Error + 'static> Error for ErrorWithContext<E> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.error)
+    }
+}
+
+pub(crate) trait ResultExt<T, E> {
+    fn context(self, message: impl Into<Cow<'static, str>>) -> Result<T, ErrorWithContext<E>>;
+}
+
+impl<T, E> ResultExt<T, E> for Result<T, E> {
+    fn context(self, message: impl Into<Cow<'static, str>>) -> Result<T, ErrorWithContext<E>> {
+        match self {
+            Ok(ok) => Ok(ok),
+            Err(error) => Err(ErrorWithContext {
+                message: message.into(),
+                error,
+            }),
+        }
+    }
+}


### PR DESCRIPTION
I'm not convinced of the dynamicism being used here (boxed "handler" functions that are ultimately just a hardcoded list apparently?), but changing that would be a larger refactor so I opted for a very simple anyhow-like context wrapper for adding more error information.