### PR TITLE
moss: Add support for simulating privileged operations

### DIFF
--- a/boulder/src/build/root.rs
+++ b/boulder/src/build/root.rs
@@ -44,7 +44,7 @@ pub fn populate(
     timing.finish(initialize_timer);
 
     // Install packages
-    let install_timing = moss_client.install(&packages, true)?;
+    let install_timing = moss_client.install(&packages, true, false)?;
 
     timing.record(timing::Populate::Resolve, install_timing.resolve);
     timing.record(timing::Populate::Fetch, install_timing.fetch);

--- a/moss/src/cli/install.rs
+++ b/moss/src/cli/install.rs
@@ -26,6 +26,10 @@ pub struct Command {
     /// Packages to install
     packages: Vec<String>,
 
+    /// Simulate the operation (dry-run)
+    #[arg(long)]
+    dry_run: bool,
+
     /// Blit this sync to the provided directory instead of the root
     ///
     /// This operation won't be captured as a new state
@@ -40,6 +44,7 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
 
     let pkgs = command.packages.iter().map(String::as_str).collect::<Vec<_>>();
     let yes = *args.get_one::<bool>("yes").unwrap();
+    let simulate = command.dry_run;
 
     // Grab a client for the root
     let mut client = Client::new(environment::NAME, installation)?;
@@ -49,7 +54,7 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
         client = client.ephemeral(blit_target)?;
     }
 
-    client.install(&pkgs, yes)?;
+    client.install(&pkgs, yes, simulate)?;
 
     Ok(())
 }

--- a/moss/src/cli/install.rs
+++ b/moss/src/cli/install.rs
@@ -4,45 +4,48 @@
 
 use std::path::PathBuf;
 
-use clap::{ArgMatches, Command, arg, value_parser};
+use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser};
+
 use moss::{Installation, client::Client, environment};
 use tracing::instrument;
 
 pub use moss::client::Error;
 
-pub fn command() -> Command {
-    Command::new("install")
-        .visible_alias("it")
-        .about("Install packages")
-        .long_about("Install the requested software to the local system")
-        .arg(arg!(<NAME> ... "packages to install").value_parser(value_parser!(String)))
-        .arg(
-            arg!(--to <blit_target> "Blit this install to the provided directory instead of the root")
-                .help(
-                    "Blit this install to the provided directory instead of the root. \n\
-                     \n\
-                     This operation won't be captured as a new state",
-                )
-                .value_parser(value_parser!(PathBuf)),
-        )
+pub fn command() -> clap::Command {
+    Command::command()
+}
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "install",
+    visible_alias = "it",
+    about = "Install packages",
+    long_about = "Install packages by name"
+)]
+pub struct Command {
+    /// Packages to install
+    packages: Vec<String>,
+
+    /// Blit this sync to the provided directory instead of the root
+    ///
+    /// This operation won't be captured as a new state
+    #[arg(value_name = "dir", long = "to")]
+    blit_target: Option<PathBuf>,
 }
 
 /// Handle execution of `moss install`
 #[instrument(skip_all)]
 pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error> {
-    let pkgs = args
-        .get_many::<String>("NAME")
-        .into_iter()
-        .flatten()
-        .map(String::as_str)
-        .collect::<Vec<_>>();
+    let command = Command::from_arg_matches(args).expect("validated by clap");
+
+    let pkgs = command.packages.iter().map(String::as_str).collect::<Vec<_>>();
     let yes = *args.get_one::<bool>("yes").unwrap();
 
     // Grab a client for the root
     let mut client = Client::new(environment::NAME, installation)?;
 
     // Make ephemeral if a blit target was provided
-    if let Some(blit_target) = args.get_one::<PathBuf>("to").cloned() {
+    if let Some(blit_target) = command.blit_target {
         client = client.ephemeral(blit_target)?;
     }
 

--- a/moss/src/cli/remove.rs
+++ b/moss/src/cli/remove.rs
@@ -2,30 +2,35 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use clap::{ArgMatches, Command, arg};
+use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser};
 
 use moss::{Installation, client::Client, environment};
 use tracing::instrument;
 
 pub use moss::client::Error;
 
-pub fn command() -> Command {
-    Command::new("remove")
-        .visible_alias("rm")
-        .about("Remove packages")
-        .long_about("Remove packages by name")
-        .arg(arg!(<NAME> ... "packages to remove").value_parser(clap::value_parser!(String)))
+pub fn command() -> clap::Command {
+    Command::command()
+}
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "remove",
+    visible_alias = "rm",
+    about = "Remove packages",
+    long_about = "Remove packages by name"
+)]
+pub struct Command {
+    /// Packages to remove
+    packages: Vec<String>,
 }
 
 /// Handle execution of `moss remove`
 #[instrument(skip_all)]
 pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error> {
-    let pkgs = args
-        .get_many::<String>("NAME")
-        .into_iter()
-        .flatten()
-        .map(String::as_str)
-        .collect::<Vec<_>>();
+    let command = Command::from_arg_matches(args).expect("validated by clap");
+
+    let pkgs = command.packages.iter().map(String::as_str).collect::<Vec<_>>();
     let yes = *args.get_one::<bool>("yes").unwrap();
 
     let mut client = Client::new(environment::NAME, installation)?;

--- a/moss/src/cli/remove.rs
+++ b/moss/src/cli/remove.rs
@@ -23,6 +23,10 @@ pub fn command() -> clap::Command {
 pub struct Command {
     /// Packages to remove
     packages: Vec<String>,
+
+    /// Simulate the operation (dry-run)
+    #[arg(long)]
+    dry_run: bool,
 }
 
 /// Handle execution of `moss remove`
@@ -32,10 +36,11 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
 
     let pkgs = command.packages.iter().map(String::as_str).collect::<Vec<_>>();
     let yes = *args.get_one::<bool>("yes").unwrap();
+    let simulate = command.dry_run;
 
     let mut client = Client::new(environment::NAME, installation)?;
 
-    client.remove(&pkgs, yes)?;
+    client.remove(&pkgs, yes, simulate)?;
 
     Ok(())
 }

--- a/moss/src/cli/sync.rs
+++ b/moss/src/cli/sync.rs
@@ -31,6 +31,10 @@ pub struct Command {
     #[arg(value_name = "dir", long = "to")]
     blit_target: Option<PathBuf>,
 
+    /// Simulate the sync (dry-run)
+    #[arg(long)]
+    dry_run: bool,
+
     /// Sync against the provided system-model.kdl
     ///
     /// Only the repositories and packages from the provided file
@@ -44,6 +48,7 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
     let command = Command::from_arg_matches(args).expect("validated by clap");
 
     let yes = *args.get_one::<bool>("yes").unwrap();
+    let simulate = command.dry_run;
     let update = command.update;
 
     let mut client = Client::new(environment::NAME, installation)?;
@@ -58,7 +63,7 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
         runtime::block_on(client.refresh_repositories())?;
     }
 
-    client.sync(command.import.as_deref(), yes)?;
+    client.sync(command.import.as_deref(), yes, simulate)?;
 
     Ok(())
 }

--- a/moss/src/client/install.rs
+++ b/moss/src/client/install.rs
@@ -27,7 +27,7 @@ use crate::{
 /// If this call is successful a new State is recorded into the [`super::db::state::Database`].
 /// Upon completion the `/usr` tree is "hot swapped" with the staging tree through `renameat2` call.
 #[instrument(skip(client), fields(ephemeral = client.is_ephemeral()))]
-pub fn install(client: &mut Client, pkgs: &[&str], yes: bool) -> Result<Timing, Error> {
+pub fn install(client: &mut Client, pkgs: &[&str], yes: bool, simulate: bool) -> Result<Timing, Error> {
     let mut timing = Timing::default();
     let mut instant = Instant::now();
 
@@ -89,6 +89,10 @@ pub fn install(client: &mut Client, pkgs: &[&str], yes: bool) -> Result<Timing, 
     println!();
     autoprint_columns(&missing);
     println!();
+
+    if simulate {
+        return Ok(timing);
+    }
 
     // Must we prompt?
     let result = if yes {

--- a/moss/src/client/mod.rs
+++ b/moss/src/client/mod.rs
@@ -157,8 +157,8 @@ impl Client {
     }
 
     /// Perform a sync
-    pub fn sync(&mut self, import: Option<&Path>, yes: bool) -> Result<sync::Timing, Error> {
-        sync(self, import, yes).map_err(|error| Error::Sync(Box::new(error)))
+    pub fn sync(&mut self, import: Option<&Path>, yes: bool, simulate: bool) -> Result<sync::Timing, Error> {
+        sync(self, import, yes, simulate).map_err(|error| Error::Sync(Box::new(error)))
     }
 
     /// Transition to an ephemeral client that doesn't record state changes

--- a/moss/src/client/mod.rs
+++ b/moss/src/client/mod.rs
@@ -142,8 +142,8 @@ impl Client {
     }
 
     /// Perform package installation
-    pub fn install(&mut self, packages: &[&str], yes: bool) -> Result<install::Timing, Error> {
-        install(self, packages, yes).map_err(|error| Error::Install(Box::new(error)))
+    pub fn install(&mut self, packages: &[&str], yes: bool, simulate: bool) -> Result<install::Timing, Error> {
+        install(self, packages, yes, simulate).map_err(|error| Error::Install(Box::new(error)))
     }
 
     /// Perform package removals

--- a/moss/src/client/mod.rs
+++ b/moss/src/client/mod.rs
@@ -147,8 +147,8 @@ impl Client {
     }
 
     /// Perform package removals
-    pub fn remove(&mut self, packages: &[&str], yes: bool) -> Result<remove::Timing, Error> {
-        remove(self, packages, yes).map_err(|error| Error::Remove(Box::new(error)))
+    pub fn remove(&mut self, packages: &[&str], yes: bool, simulate: bool) -> Result<remove::Timing, Error> {
+        remove(self, packages, yes, simulate).map_err(|error| Error::Remove(Box::new(error)))
     }
 
     /// Perform package fetches

--- a/moss/src/client/remove.rs
+++ b/moss/src/client/remove.rs
@@ -16,7 +16,7 @@ use crate::{Client, Provider, client, db, registry::transaction, state::Selectio
 
 /// Remove a set of packages.
 #[instrument(skip(client), fields(ephemeral = client.is_ephemeral()))]
-pub fn remove(client: &mut Client, pkgs: &[&str], yes: bool) -> Result<Timing, Error> {
+pub fn remove(client: &mut Client, pkgs: &[&str], yes: bool, simulate: bool) -> Result<Timing, Error> {
     let mut timing = Timing::default();
     let mut instant = Instant::now();
 
@@ -99,6 +99,10 @@ pub fn remove(client: &mut Client, pkgs: &[&str], yes: bool) -> Result<Timing, E
     println!();
     autoprint_columns(&removed);
     println!();
+
+    if simulate {
+        return Ok(timing);
+    }
 
     let result = if yes {
         true

--- a/moss/src/client/sync.rs
+++ b/moss/src/client/sync.rs
@@ -17,7 +17,7 @@ use crate::{
     system_model,
 };
 
-pub fn sync(client: &Client, import: Option<&Path>, yes: bool) -> Result<Timing, Error> {
+pub fn sync(client: &Client, import: Option<&Path>, yes: bool, simulate: bool) -> Result<Timing, Error> {
     let mut timing = Timing::default();
     let mut instant = Instant::now();
 
@@ -108,6 +108,10 @@ pub fn sync(client: &Client, import: Option<&Path>, yes: bool) -> Result<Timing,
         println!();
     }
 
+    if simulate {
+        return Ok(timing);
+    }
+
     // Must we prompt?
     let result = if yes {
         true
@@ -147,12 +151,12 @@ pub fn sync(client: &Client, import: Option<&Path>, yes: bool) -> Result<Timing,
         // For system model, "explicit" is what was defined in the system model file
 
         finalized
-            .into_iter()
+            .iter()
             .map(|p| {
                 let is_explicit = system_model.packages.intersection(&p.meta.providers).next().is_some();
 
                 Selection {
-                    package: p.id,
+                    package: p.id.clone(),
                     explicit: is_explicit,
                     // TODO: We can map the "why" of system-model packages to this? Or
                     // can we remove "reason" entirely, we haven't used it to-date
@@ -168,7 +172,7 @@ pub fn sync(client: &Client, import: Option<&Path>, yes: bool) -> Result<Timing,
         };
 
         finalized
-            .into_iter()
+            .iter()
             .map(|p| {
                 // Use old version id to lookup previous selection
                 let lookup_id = installed
@@ -187,7 +191,7 @@ pub fn sync(client: &Client, import: Option<&Path>, yes: bool) -> Result<Timing,
                     })
                     // Must be transitive
                     .unwrap_or(Selection {
-                        package: p.id,
+                        package: p.id.clone(),
                         explicit: false,
                         reason: None,
                     })


### PR DESCRIPTION
Currently, it is effectively just an early return, but, it can be helpful to ensure dependency trees.

This is preliminary groundwork for the moss packagekit backend as packagekit always simulates operations first and we want the end high-level API to support this. 