### PR TITLE
moss: UX & perf. improvings for removing stale states

### DIFF
--- a/moss/src/client/prune.rs
+++ b/moss/src/client/prune.rs
@@ -9,6 +9,9 @@
 //! and assets on disk by way of refcounting.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
 use std::{
     io,
     path::{Path, PathBuf},
@@ -18,6 +21,8 @@ use fs_err as fs;
 use itertools::Itertools;
 use thiserror::Error;
 
+use tracing::info;
+use tui::{ProgressBar, ProgressStyle};
 use tui::{
     dialoguer::{Confirm, theme::ColorfulTheme},
     pretty::autoprint_columns,
@@ -43,6 +48,9 @@ pub(super) fn prune_states(client: &Client, strategy: Strategy<'_>, yes: bool) -
     let layout_db = &client.layout_db;
     let state_db = &client.state_db;
     let install_db = &client.install_db;
+
+    let mut timing = Timing::default();
+    let mut instant = Instant::now();
 
     // Only prune if the moss root has an active state (otherwise
     // it's probably borked or not setup yet)
@@ -129,6 +137,15 @@ pub(super) fn prune_states(client: &Client, strategy: Strategy<'_>, yes: bool) -
         .filter_map(|(pkg, count)| (count == 0).then_some(pkg))
         .collect::<Vec<_>>();
 
+    timing.resolve = instant.elapsed();
+    info!(
+        total_resolved_states = removals.len(),
+        total_resolved_packages = package_removals.len(),
+        resolve_time_ms = timing.resolve.as_millis(),
+        "Resolved states marked for removal"
+    );
+    instant = Instant::now();
+
     // Print out the states to be removed to the user
     println!("The following state(s) will be removed:");
     println!();
@@ -150,6 +167,13 @@ pub(super) fn prune_states(client: &Client, strategy: Strategy<'_>, yes: bool) -
     // Prune these states / packages from all dbs
     prune_databases(&removals, &package_removals, state_db, install_db, layout_db)?;
 
+    timing.prune_db = instant.elapsed();
+    info!(
+        prune_db_time_ms = timing.prune_db.as_millis(),
+        "Pruned stale packages & states from databases"
+    );
+    instant = Instant::now();
+
     // Remove orphaned downloads
     remove_orphaned_files(
         // root
@@ -170,12 +194,56 @@ pub(super) fn prune_states(client: &Client, strategy: Strategy<'_>, yes: bool) -
         |hash| Some(cache::asset_path(installation, &hash)),
     )?;
 
+    timing.orphaned_files = instant.elapsed();
+    info!(
+        orphaned_file_time_ms = timing.orphaned_files.as_millis(),
+        "Removed orphaned files"
+    );
+    instant = Instant::now();
+
     let archive_paths = removals
         .iter()
         .map(|s| installation.root_path(s.id.to_string()))
         .collect::<Vec<_>>();
 
-    util::par_remove_dirs_all(archive_paths.iter().map(|p| p.as_path()).collect(), |_, _| {})?;
+    info!(
+        total_archived_paths = archive_paths.len(),
+        progress = 0.0,
+        event_type = "progress_start",
+        "Removing stale archive trees"
+    );
+
+    let progressbar = ProgressBar::new(archive_paths.len() as u64)
+        .with_style(ProgressStyle::with_template("\n|{bar:20.cyan/blue}| {pos}/{len}").unwrap());
+
+    let counter = Arc::new(AtomicUsize::new(0));
+    util::par_remove_dirs_all(
+        archive_paths.iter().map(|p| p.as_path()).collect(),
+        |path, res| match res {
+            Ok(_) => {
+                counter.fetch_add(1, Ordering::Relaxed);
+                let cnt = counter.load(Ordering::Relaxed);
+                info!(
+                    progress = cnt as f32 / archive_paths.len() as f32,
+                    current = cnt,
+                    total = archive_paths.len(),
+                    event_type = "progress_update",
+                    "Removed archived state: {:?}",
+                    path
+                );
+                progressbar.inc(1);
+            }
+            Err(e) => eprintln!("Failed to remove archived state: {path:?} ({e})"),
+        },
+    )?;
+
+    timing.prune_archives = instant.elapsed();
+    info!(
+        duration_ms = timing.prune_archives.as_millis(),
+        items_processed = archive_paths.len(),
+        progress = 1.0,
+        event_type = "progress_completed",
+    );
 
     // Sync boot to ensure pruned states are removed from boot entries
     boot::synchronize(client, &current_state).map_err(Error::SyncBoot)?;
@@ -408,6 +476,15 @@ fn remove_empty_dirs(starting: &Path, root: &Path) -> io::Result<()> {
     }
 
     Ok(())
+}
+
+/// Simple timing information for Prune
+#[derive(Default)]
+pub struct Timing {
+    pub resolve: Duration,
+    pub prune_db: Duration,
+    pub orphaned_files: Duration,
+    pub prune_archives: Duration,
 }
 
 #[derive(Debug, Error)]

--- a/moss/src/client/prune.rs
+++ b/moss/src/client/prune.rs
@@ -24,6 +24,7 @@ use tui::{
 };
 
 use crate::client::boot;
+use crate::util;
 use crate::{Client, Installation, State, client::cache, db, package, repository, state};
 
 /// The prune strategy for removing old states
@@ -169,14 +170,12 @@ pub(super) fn prune_states(client: &Client, strategy: Strategy<'_>, yes: bool) -
         |hash| Some(cache::asset_path(installation, &hash)),
     )?;
 
-    // Remove each state's archive folder
-    for state in removals {
-        let archive_path = installation.root_path(state.id.to_string());
+    let archive_paths = removals
+        .iter()
+        .map(|s| installation.root_path(s.id.to_string()))
+        .collect::<Vec<_>>();
 
-        if archive_path.exists() {
-            fs::remove_dir_all(&archive_path)?;
-        }
-    }
+    util::par_remove_dirs_all(archive_paths.iter().map(|p| p.as_path()).collect(), |_, _| {})?;
 
     // Sync boot to ensure pruned states are removed from boot entries
     boot::synchronize(client, &current_state).map_err(Error::SyncBoot)?;

--- a/moss/src/client/prune.rs
+++ b/moss/src/client/prune.rs
@@ -22,7 +22,7 @@ use itertools::Itertools;
 use thiserror::Error;
 
 use tracing::info;
-use tui::{ProgressBar, ProgressStyle};
+use tui::{ProgressBar, ProgressStyle, Styled};
 use tui::{
     dialoguer::{Confirm, theme::ColorfulTheme},
     pretty::autoprint_columns,
@@ -213,29 +213,7 @@ pub(super) fn prune_states(client: &Client, strategy: Strategy<'_>, yes: bool) -
         "Removing stale archive trees"
     );
 
-    let progressbar = ProgressBar::new(archive_paths.len() as u64)
-        .with_style(ProgressStyle::with_template("\n|{bar:20.cyan/blue}| {pos}/{len}").unwrap());
-
-    let counter = Arc::new(AtomicUsize::new(0));
-    util::par_remove_dirs_all(
-        archive_paths.iter().map(|p| p.as_path()).collect(),
-        |path, res| match res {
-            Ok(_) => {
-                counter.fetch_add(1, Ordering::Relaxed);
-                let cnt = counter.load(Ordering::Relaxed);
-                info!(
-                    progress = cnt as f32 / archive_paths.len() as f32,
-                    current = cnt,
-                    total = archive_paths.len(),
-                    event_type = "progress_update",
-                    "Removed archived state: {:?}",
-                    path
-                );
-                progressbar.inc(1);
-            }
-            Err(e) => eprintln!("Failed to remove archived state: {path:?} ({e})"),
-        },
-    )?;
+    remove_archived_states(&archive_paths)?;
 
     timing.prune_archives = instant.elapsed();
     info!(
@@ -474,6 +452,40 @@ fn remove_empty_dirs(starting: &Path, root: &Path) -> io::Result<()> {
             current = Some(parent);
         }
     }
+
+    Ok(())
+}
+
+fn remove_archived_states(archive_paths: &[PathBuf]) -> Result<(), Error> {
+    println!();
+
+    let progressbar = ProgressBar::new(archive_paths.len() as u64).with_style(
+        ProgressStyle::with_template("\n|{bar:20.cyan/blue}| {pos}/{len}")
+            .unwrap()
+            .progress_chars("■= "),
+    );
+    progressbar.tick();
+
+    let counter = Arc::new(AtomicUsize::new(0));
+
+    util::par_remove_dirs_all(archive_paths, |path, res| match res {
+        Ok(_) => {
+            let cnt = counter.fetch_add(1, Ordering::Relaxed) + 1;
+            info!(
+                progress = cnt as f32 / archive_paths.len() as f32,
+                current = cnt,
+                total = archive_paths.len(),
+                event_type = "progress_update",
+                "Removed archived state: {:?}",
+                path
+            );
+            progressbar.inc(1);
+            progressbar.suspend(|| println!("{} {path:?}", "Removed".green()));
+        }
+        Err(e) => eprintln!("Failed to remove archived state: {path:?} ({e})"),
+    })?;
+
+    progressbar.finish_and_clear();
 
     Ok(())
 }

--- a/moss/src/util.rs
+++ b/moss/src/util.rs
@@ -208,15 +208,15 @@ pub fn par_remove_dir_all(path: &Path) -> io::Result<()> {
 ///
 /// Provides a callback tuple of `Path` and `io::Result` once each element in paths is completed with it's
 /// result
-pub fn par_remove_dirs_all<P>(paths: Vec<&Path>, progress: P) -> io::Result<()>
+pub fn par_remove_dirs_all<P>(paths: &[PathBuf], progress: P) -> io::Result<()>
 where
     P: Fn(&Path, &io::Result<()>) + Sync,
 {
     let rayon_runtime = rayon::ThreadPoolBuilder::new().build().expect("rayon runtime");
 
     rayon_runtime.install(|| -> io::Result<()> {
-        paths.par_iter().try_for_each(|path| -> io::Result<()> {
-            let result: io::Result<()> = (|| {
+        paths.par_iter().try_for_each(|path| {
+            let result = (|| {
                 let filetype = match fs::symlink_metadata(path) {
                     Ok(metadata) => metadata.file_type(),
                     Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),

--- a/moss/src/util.rs
+++ b/moss/src/util.rs
@@ -13,7 +13,7 @@ use std::{
 
 use fs_err as fs;
 use nix::unistd::{LinkatFlags, linkat};
-use rayon::iter::{ParallelBridge, ParallelIterator};
+use rayon::iter::{IntoParallelRefIterator, ParallelBridge, ParallelIterator};
 use sha2::{Digest, Sha256};
 use stone::{StoneDecodedPayload, StoneReadError};
 use tokio::io::AsyncRead;
@@ -198,6 +198,39 @@ pub fn par_remove_dir_all(path: &Path) -> io::Result<()> {
         } else {
             par_remove_dir_all_recursive(path)
         }
+    })?;
+    Ok(())
+}
+
+/// Removes a set of directories provided, after removing all of their contents in parallel. Use carefully!
+///
+/// Ignores `NotFound` error if any of the root paths do not exist.
+///
+/// Provides a callback tuple of `Path` and `io::Result` once each element in paths is completed with it's
+/// result
+pub fn par_remove_dirs_all<P>(paths: Vec<&Path>, progress: P) -> io::Result<()>
+where
+    P: Fn(&Path, &io::Result<()>) + Sync,
+{
+    let rayon_runtime = rayon::ThreadPoolBuilder::new().build().expect("rayon runtime");
+
+    rayon_runtime.install(|| -> io::Result<()> {
+        paths.par_iter().try_for_each(|path| -> io::Result<()> {
+            let result: io::Result<()> = (|| {
+                let filetype = match fs::symlink_metadata(path) {
+                    Ok(metadata) => metadata.file_type(),
+                    Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
+                    Err(e) => return Err(e),
+                };
+                if filetype.is_symlink() {
+                    fs::remove_file(path)
+                } else {
+                    par_remove_dir_all_recursive(path)
+                }
+            })();
+            progress(path, &result);
+            result
+        })
     })?;
     Ok(())
 }


### PR DESCRIPTION
Add tracing and progress bar output when removing states

Use a parallelized recursive function that can remove all the stale states in one call

On an NVME drive on a modern system for the same pkg lists (hot) Before: 0m3.364s Now: 0m2.284s