### PR TITLE
boulder: data: cmake: Escape quotes around "Unix Makefiles"

### DIFF
--- a/boulder/data/macros/actions/cmake.yaml
+++ b/boulder/data/macros/actions/cmake.yaml
@@ -72,5 +72,5 @@ definitions:
 
     # Use cmake with make as the build server
     - options_cmake_make: |
-        -G "Unix Makefiles" \
+        -G \"Unix Makefiles\" \
         %(options_cmake)


### PR DESCRIPTION
When `boulder chroot` is run, all actions are appended into ~/.profile. This particular line is rendered as:

    d_options_cmake_make="-G "Unix Makefiles" \
    -B "aerynos-builddir" \
    [snip]

So we're closing the quoted string after `-G ` and reopening it after `Makefiles`. This returns the following error when ~/.profile is sourced:

zsh: file name too long: Makefiles -B aerynos-builddir [snip]

To solve such error it is sufficient to escape the quotes, so that the quoted string is never broken apart.