### PR TITLE
moss/cli: Add preliminary root check before managing boot items

### DIFF
--- a/moss/src/cli/boot.rs
+++ b/moss/src/cli/boot.rs
@@ -17,6 +17,10 @@ pub fn command() -> Command {
 
 /// Handle status for now
 pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error> {
+    if nix::unistd::geteuid() != 0.into() {
+        return Err(Error::MossBootRootIsRequired);
+    }
+
     match args.subcommand() {
         Some(("status", args)) => status(args, installation),
         Some(("sync", args)) => sync(args, installation),
@@ -46,6 +50,8 @@ fn sync(_args: &ArgMatches, installation: Installation) -> Result<(), Error> {
 
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("root is required to manage & view boot configuration")]
+    MossBootRootIsRequired,
     #[error("client")]
     Client(#[from] client::Error),
 }


### PR DESCRIPTION
Currently, we allow any permissions issues to fail at execution time, however, boot status will report:

`XBOOTLDR       : None`

Even when an XBOOTLDR partition is present unless ran with root.

Therefore do a prelim root check on this code path