### PR TITLE
crates: gitwrap: Achieve REUSE compliance

### DIFF
--- a/crates/gitwrap/Cargo.toml
+++ b/crates/gitwrap/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 [package]
 name = "gitwrap"
 edition = "2021"

--- a/crates/gitwrap/src/error.rs
+++ b/crates/gitwrap/src/error.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 use std::{fmt, io};
 
 /// The error type for operations using the `git` executable.

--- a/crates/gitwrap/src/lib.rs
+++ b/crates/gitwrap/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
 //! Git repository manipulation utilities based
 //! on the `git` executable.
 //!


### PR DESCRIPTION
This PR just makes REUSE checks pass.

While we were developing gitwrap, we in parallel introduced checks for REUSE compliance. I did not feel like adding a new commit to the PR of gitwrap (#761) because it was pretty big and controversial for some aspects. I wanted it to be stable for the sake of the review process.

Now that we merged both the REUSE checks and gitwrap, it's time to make it pass REUSE checks.