### PR TITLE
boulder: Robustify thread priority setter for build

### DIFF
--- a/boulder/src/cli/build.rs
+++ b/boulder/src/cli/build.rs
@@ -111,11 +111,22 @@ pub fn handle(command: Command, env: Env) -> Result<(), Error> {
 
     // Set the current thread priority to SCHED_BATCH so that it's inherited by all child processes
     if !normal_priority {
-        thread_priority::set_thread_priority_and_policy(
+        println!("Changing boulder thread priority to SCHED_BATCH during build:");
+        match thread_priority::set_thread_priority_and_policy(
             thread_native_id(),
             ThreadPriority::Min,
             ThreadSchedulePolicy::Normal(NormalThreadSchedulePolicy::Batch),
-        )?;
+        ) {
+            Ok(_) => {
+                println!("└─ priority set.\n");
+            }
+            Err(e) => {
+                println!("└─ unable to change boulder thread scheduling priority to SCHED_BATCH.");
+                println!("   └─ '{e:?}'");
+                println!("   └─ ignoring inconsequential error.\n");
+            }
+        }
+        println!("Continuing build:\n");
     }
 
     // hold a fd

--- a/boulder/src/upstream.rs
+++ b/boulder/src/upstream.rs
@@ -133,7 +133,7 @@ pub fn sync(
     share_dir: &Path,
 ) -> Result<Vec<Stored>, Error> {
     println!();
-    println!("Sharing {} upstream(s) with the build container", upstreams.len());
+    println!("Sharing {} upstream(s) with the build container:", upstreams.len());
 
     let mp = MultiProgress::new();
     let tp = mp.add(


### PR DESCRIPTION
Without this, if the system76-scheduler is enabled, boulder will error out when trying to set the build process to SCHED_BATCH priority.