### PR TITLE
moss: Add testing flag to dev-deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,6 +2070,7 @@ dependencies = [
  "kdl",
  "libsqlite3-sys",
  "log",
+ "moss",
  "nix 0.27.1",
  "os-info",
  "rayon",

--- a/justfile
+++ b/justfile
@@ -81,7 +81,7 @@ lint:
 # Run tests
 test: lint
   @echo "Running tests in all packages…"
-  cargo test --all --features moss/testing
+  cargo test --all
 
 # Run all DB migrations
 migrate: (diesel "meta" "migration run") (diesel "layout" "migration run") (diesel "state" "migration run")

--- a/moss/Cargo.toml
+++ b/moss/Cargo.toml
@@ -58,6 +58,8 @@ zbus.workspace = true
 astr = { workspace = true, features = ["diesel"] }
 
 [dev-dependencies]
+moss = { path = ".", features = ["testing"] }
+
 tempfile.workspace = true
 
 [package.metadata.cargo-machete]


### PR DESCRIPTION
Adds `testing` as a `dev-dependencies` so one doesn't need `--features testing` for `cargo test` to work. It works by default now.