### PR TITLE
crates/version_parse: Improve VcsProviders support and fixes for github/gitlab/codeberg

### DIFF
--- a/crates/version_parse/src/lib.rs
+++ b/crates/version_parse/src/lib.rs
@@ -56,7 +56,7 @@ const VCS_PROVIDERS: &[VcsProvider] = &[
     },
     VcsProvider {
         host: "gitlab.com",
-        path_contains: "repository/archive.tar.gz",
+        path_contains: "/-/archive/",
     },
     VcsProvider {
         host: "codeberg.org",
@@ -391,6 +391,22 @@ mod tests {
                 Extraction {
                     version: "1.2.1".to_string(),
                     name: "gram".to_string(),
+                    release_series: None,
+                },
+            ),
+            (
+                "https://gitlab.com/serebit/wraith-master/-/archive/v1.2.1/wraith-master-v1.2.1.tar.gz",
+                Extraction {
+                    version: "1.2.1".to_string(),
+                    name: "wraith-master".to_string(),
+                    release_series: None,
+                },
+            ),
+            (
+                "https://gitlab.com/flightgear/flightgear/-/archive/2024.1.5/flightgear-2024.1.5.tar.gz?ref_type=tags",
+                Extraction {
+                    version: "2024.1.5".to_string(),
+                    name: "flightgear".to_string(),
                     release_series: None,
                 },
             ),

--- a/crates/version_parse/src/lib.rs
+++ b/crates/version_parse/src/lib.rs
@@ -46,21 +46,21 @@ pub struct VersionPattern {
 
 struct VcsProvider {
     host: &'static str,
-    path_contains: &'static str,
+    path_contains: &'static [&'static str],
 }
 
 const VCS_PROVIDERS: &[VcsProvider] = &[
     VcsProvider {
         host: "github.com",
-        path_contains: "archive/refs/tags/",
+        path_contains: &["archive/refs/tags/"],
     },
     VcsProvider {
         host: "gitlab.com",
-        path_contains: "/-/archive/",
+        path_contains: &["/-/archive/"],
     },
     VcsProvider {
         host: "codeberg.org",
-        path_contains: "/archive/",
+        path_contains: &["/archive/"],
     },
 ];
 
@@ -242,7 +242,7 @@ impl VersionExtractor {
 
         let _provider = VCS_PROVIDERS
             .iter()
-            .find(|p| p.host == host && url.path().contains(p.path_contains))?;
+            .find(|p| p.host == host && p.path_contains.iter().any(|s| url.path().contains(s)))?;
 
         let parts: Vec<&str> = url.path().split('/').collect();
         let project = parts.get(2)?;

--- a/crates/version_parse/src/lib.rs
+++ b/crates/version_parse/src/lib.rs
@@ -213,7 +213,7 @@ impl VersionExtractor {
 
     /// Attempts to extract version info from GitHub/GitLab URLs
     fn try_extract_vcs_url(&self, path: &str) -> Option<Result<Extraction, VersionError>> {
-        if !path.contains("github.com") && !path.contains("gitlab.com") {
+        if !path.contains("github.com") && !path.contains("gitlab.com") && !path.contains("codeberg.org") {
             return None;
         }
 
@@ -234,6 +234,16 @@ impl VersionExtractor {
                 let parts: Vec<&str> = url.path().split('/').collect();
                 let project = parts.get(2)?;
                 let faux = format!("{project}-archive.tar.gz");
+                Some(self.extract(&faux).map(|matched| Extraction {
+                    name: project.to_string(),
+                    ..matched
+                }))
+            }
+            Some("codeberg.org") if url.path().contains("/archive/") => {
+                let parts: Vec<&str> = url.path().split('/').collect();
+                let project = parts.get(2)?;
+                let asset = parts.last()?;
+                let faux = format!("{project}-{asset}");
                 Some(self.extract(&faux).map(|matched| Extraction {
                     name: project.to_string(),
                     ..matched
@@ -371,6 +381,14 @@ mod tests {
                 Extraction {
                     version: "1.0.0-alpha.6".to_string(),
                     name: "cosmic-applets".to_string(),
+                    release_series: None,
+                },
+            ),
+            (
+                "https://codeberg.org/GramEditor/gram/archive/1.2.1.tar.gz",
+                Extraction {
+                    version: "1.2.1".to_string(),
+                    name: "gram".to_string(),
                     release_series: None,
                 },
             ),

--- a/crates/version_parse/src/lib.rs
+++ b/crates/version_parse/src/lib.rs
@@ -44,6 +44,26 @@ pub struct VersionPattern {
     pub priority: u8,
 }
 
+struct VcsProvider {
+    host: &'static str,
+    path_contains: &'static str,
+}
+
+const VCS_PROVIDERS: &[VcsProvider] = &[
+    VcsProvider {
+        host: "github.com",
+        path_contains: "archive/refs/tags/",
+    },
+    VcsProvider {
+        host: "gitlab.com",
+        path_contains: "repository/archive.tar.gz",
+    },
+    VcsProvider {
+        host: "codeberg.org",
+        path_contains: "/archive/",
+    },
+];
+
 impl VersionPattern {
     /// Creates a new version pattern
     ///
@@ -211,46 +231,28 @@ impl VersionExtractor {
         Err(VersionError::InvalidVersion { path: path.to_owned() })
     }
 
-    /// Attempts to extract version info from GitHub/GitLab URLs
+    /// Attempts to extract version info from URLs from known VCS providers
     fn try_extract_vcs_url(&self, path: &str) -> Option<Result<Extraction, VersionError>> {
-        if !path.contains("github.com") && !path.contains("gitlab.com") && !path.contains("codeberg.org") {
+        if !VCS_PROVIDERS.iter().any(|p| path.contains(p.host)) {
             return None;
         }
 
         let url = Url::parse(path).ok()?;
+        let host = url.host_str()?;
 
-        match url.host_str() {
-            Some("github.com") if url.path().contains("archive/refs/tags/") => {
-                let parts: Vec<&str> = url.path().split('/').collect();
-                let project = parts.get(2)?;
-                let asset = parts.last()?;
-                let faux = format!("{project}-{asset}");
-                Some(self.extract(&faux).map(|matched| Extraction {
-                    name: project.to_string(),
-                    ..matched
-                }))
-            }
-            Some("gitlab.com") if url.path().contains("repository/archive.tar.gz") => {
-                let parts: Vec<&str> = url.path().split('/').collect();
-                let project = parts.get(2)?;
-                let faux = format!("{project}-archive.tar.gz");
-                Some(self.extract(&faux).map(|matched| Extraction {
-                    name: project.to_string(),
-                    ..matched
-                }))
-            }
-            Some("codeberg.org") if url.path().contains("/archive/") => {
-                let parts: Vec<&str> = url.path().split('/').collect();
-                let project = parts.get(2)?;
-                let asset = parts.last()?;
-                let faux = format!("{project}-{asset}");
-                Some(self.extract(&faux).map(|matched| Extraction {
-                    name: project.to_string(),
-                    ..matched
-                }))
-            }
-            _ => None,
-        }
+        let _provider = VCS_PROVIDERS
+            .iter()
+            .find(|p| p.host == host && url.path().contains(p.path_contains))?;
+
+        let parts: Vec<&str> = url.path().split('/').collect();
+        let project = parts.get(2)?;
+        let asset = parts.last()?;
+        let faux = format!("{project}-{asset}");
+
+        Some(self.extract(&faux).map(|matched| Extraction {
+            name: project.to_string(),
+            ..matched
+        }))
     }
 }
 

--- a/crates/version_parse/src/lib.rs
+++ b/crates/version_parse/src/lib.rs
@@ -52,7 +52,7 @@ struct VcsProvider {
 const VCS_PROVIDERS: &[VcsProvider] = &[
     VcsProvider {
         host: "github.com",
-        path_contains: &["archive/refs/tags/"],
+        path_contains: &["archive/refs/tags/", "releases/download/"],
     },
     VcsProvider {
         host: "gitlab.com",
@@ -284,6 +284,14 @@ mod tests {
             ),
             (
                 "https://github.com/cli/cli/archive/refs/tags/v2.63.2.tar.gz",
+                Extraction {
+                    version: "2.63.2".to_string(),
+                    name: "cli".to_string(),
+                    release_series: None,
+                },
+            ),
+            (
+                "https://github.com/cli/cli/releases/download/v2.63.2/cli-2.63.2.tar.gz",
                 Extraction {
                     version: "2.63.2".to_string(),
                     name: "cli".to_string(),


### PR DESCRIPTION
- Add support for codeberg in vcs providers
- Refactor vcs providers
- Fix gitlab vcs provider support
- Add support for github downloads in vcs providers #791