### PR TITLE
Fix issue where `moss sync` with `--import` does not use the repositories in the `system-model.kdl`

### DIFF
--- a/boulder/src/build.rs
+++ b/boulder/src/build.rs
@@ -163,14 +163,10 @@ impl Builder {
 
         // Prune moss cache, retaining stones from the repos defined
         // by our boulder profile
-        {
-            moss::Client::with_explicit_repositories(
-                "boulder",
-                moss::Installation::open(&self.env.moss_dir, None)?,
-                self.repos.clone(),
-            )?
+        moss::ClientBuilder::new("boulder", moss::Installation::open(&self.env.moss_dir, None)?)
+            .repositories(self.repos.clone())
+            .build()?
             .prune_cache()?;
-        }
 
         Ok(())
     }

--- a/boulder/src/build.rs
+++ b/boulder/src/build.rs
@@ -163,7 +163,7 @@ impl Builder {
 
         // Prune moss cache, retaining stones from the repos defined
         // by our boulder profile
-        moss::ClientBuilder::new("boulder", moss::Installation::open(&self.env.moss_dir, None)?)
+        moss::Client::builder("boulder", moss::Installation::open(&self.env.moss_dir, None)?)
             .repositories(self.repos.clone())
             .build()?
             .prune_cache()?;

--- a/boulder/src/build/root.rs
+++ b/boulder/src/build/root.rs
@@ -26,8 +26,10 @@ pub fn populate(
 
     // Create the moss client
     let installation = Installation::open(&builder.env.moss_dir, None)?;
-    let mut moss_client =
-        moss::Client::with_explicit_repositories("boulder", installation, repositories)?.ephemeral(rootfs)?;
+    let mut moss_client = moss::ClientBuilder::new("boulder", installation)
+        .repositories(repositories)
+        .ephemeral(rootfs)
+        .build()?;
 
     if update_repos {
         runtime::block_on(moss_client.refresh_repositories())?;

--- a/boulder/src/build/root.rs
+++ b/boulder/src/build/root.rs
@@ -26,7 +26,7 @@ pub fn populate(
 
     // Create the moss client
     let installation = Installation::open(&builder.env.moss_dir, None)?;
-    let mut moss_client = moss::ClientBuilder::new("boulder", installation)
+    let mut moss_client = moss::Client::builder("boulder", installation)
         .repositories(repositories)
         .ephemeral(rootfs)
         .build()?;

--- a/boulder/src/cli/profile.rs
+++ b/boulder/src/cli/profile.rs
@@ -136,7 +136,9 @@ pub fn update<'a>(env: &'a Env, manager: profile::Manager<'a>, profile: &profile
     let repos = manager.repositories(profile)?.clone();
 
     let installation = Installation::open(&env.moss_dir, None)?;
-    let mut moss_client = moss::Client::with_explicit_repositories("boulder", installation, repos)?;
+    let mut moss_client = moss::ClientBuilder::new("boulder", installation)
+        .repositories(repos)
+        .build()?;
     runtime::block_on(moss_client.refresh_repositories())?;
 
     println!("Profile {profile} updated");

--- a/boulder/src/cli/profile.rs
+++ b/boulder/src/cli/profile.rs
@@ -136,7 +136,7 @@ pub fn update<'a>(env: &'a Env, manager: profile::Manager<'a>, profile: &profile
     let repos = manager.repositories(profile)?.clone();
 
     let installation = Installation::open(&env.moss_dir, None)?;
-    let mut moss_client = moss::ClientBuilder::new("boulder", installation)
+    let mut moss_client = moss::Client::builder("boulder", installation)
         .repositories(repos)
         .build()?;
     runtime::block_on(moss_client.refresh_repositories())?;

--- a/moss/src/cli/sync.rs
+++ b/moss/src/cli/sync.rs
@@ -56,12 +56,12 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
         client_builder = client_builder.system_model_path(path);
     }
 
-    let mut client = client_builder.build()?;
-
     // Make ephemeral if a blit target was provided
     if let Some(blit_target) = command.blit_target {
-        client = client.ephemeral(blit_target)?;
+        client_builder = client_builder.ephemeral(blit_target);
     }
+
+    let mut client = client_builder.build()?;
 
     // Update repos if requested
     if update {

--- a/moss/src/cli/sync.rs
+++ b/moss/src/cli/sync.rs
@@ -4,7 +4,7 @@
 use std::path::PathBuf;
 
 use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser};
-use moss::{ClientBuilder, Installation, client::Client, environment, runtime};
+use moss::{Installation, client::Client, environment, runtime};
 use tracing::instrument;
 
 pub use moss::client::Error;
@@ -50,13 +50,13 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
     let simulate = command.dry_run;
     let update = command.update;
 
-    let mut client = if let Some(path) = &command.import {
-        ClientBuilder::new(environment::NAME, installation)
-            .system_model_path(path)
-            .build()?
-    } else {
-        Client::new(environment::NAME, installation)?
-    };
+    let mut client_builder = Client::builder(environment::NAME, installation);
+
+    if let Some(path) = &command.import {
+        client_builder = client_builder.system_model_path(path);
+    }
+
+    let mut client = client_builder.build()?;
 
     // Make ephemeral if a blit target was provided
     if let Some(blit_target) = command.blit_target {

--- a/moss/src/cli/sync.rs
+++ b/moss/src/cli/sync.rs
@@ -4,7 +4,7 @@
 use std::path::PathBuf;
 
 use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser};
-use moss::{Installation, client::Client, environment, runtime};
+use moss::{ClientBuilder, Installation, client::Client, environment, runtime};
 use tracing::instrument;
 
 pub use moss::client::Error;
@@ -50,7 +50,13 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
     let simulate = command.dry_run;
     let update = command.update;
 
-    let mut client = Client::new(environment::NAME, installation)?;
+    let mut client = if let Some(path) = &command.import {
+        ClientBuilder::new(environment::NAME, installation)
+            .system_model_path(path)
+            .build()?
+    } else {
+        Client::new(environment::NAME, installation)?
+    };
 
     // Make ephemeral if a blit target was provided
     if let Some(blit_target) = command.blit_target {
@@ -62,7 +68,7 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
         runtime::block_on(client.refresh_repositories())?;
     }
 
-    client.sync(command.import.as_deref(), yes, simulate)?;
+    client.sync(yes, simulate)?;
 
     Ok(())
 }

--- a/moss/src/client/mod.rs
+++ b/moss/src/client/mod.rs
@@ -66,6 +66,54 @@ pub mod extract;
 pub mod index;
 pub mod prune;
 
+/// A builder for [`Client`]
+pub struct ClientBuilder {
+    client_name: String,
+    installation: Installation,
+    repositories: Option<repository::Map>,
+    blit_root: Option<PathBuf>,
+}
+
+impl ClientBuilder {
+    /// Construct a new ClientBuilder for the given [`Installation`]
+    pub fn new(client_name: impl ToString, installation: Installation) -> ClientBuilder {
+        ClientBuilder {
+            client_name: client_name.to_string(),
+            installation,
+            repositories: None,
+            blit_root: None,
+        }
+    }
+
+    /// Set the repositories
+    pub fn repositories(mut self, repositories: repository::Map) -> ClientBuilder {
+        self.repositories = Some(repositories);
+        self
+    }
+
+    /// Set the client to an ephemeral client that doesn't record state changes
+    /// and blits to a different root.
+    ///
+    /// This is useful for installing a root to a container (i.e. Boulder) while
+    /// using a shared cache.
+    ///
+    /// Returns an error on construction if `blit_root` is the same as the installation
+    /// root, since the system client should always be stateful.
+    pub fn ephemeral(mut self, blit_root: impl Into<PathBuf>) -> ClientBuilder {
+        self.blit_root = Some(blit_root.into());
+        self
+    }
+
+    /// Build the [`Client`]
+    pub fn build(self) -> Result<Client, Error> {
+        let mut client = Client::build(self.client_name, self.installation, self.repositories)?;
+        if let Some(blit_root) = self.blit_root {
+            client = client.ephemeral(blit_root)?;
+        }
+        Ok(client)
+    }
+}
+
 /// A Client is a connection to the underlying package management systems
 pub struct Client {
     /// Root that we operate on
@@ -89,25 +137,17 @@ pub struct Client {
 impl Client {
     /// Construct a new Client for the given [`Installation`]
     pub fn new(client_name: impl ToString, installation: Installation) -> Result<Client, Error> {
-        Self::build(client_name, installation, None)
-    }
-
-    /// Construct a new Client with explicitly configured repositories
-    pub fn with_explicit_repositories(
-        client_name: impl ToString,
-        installation: Installation,
-        repositories: repository::Map,
-    ) -> Result<Client, Error> {
-        Self::build(client_name, installation, Some(repositories))
+        Self::build(client_name.to_string(), installation, None)
     }
 
     /// Build a functioning Client for the given [`Installation`] and repositories
     fn build(
-        client_name: impl ToString,
+        client_name: String,
         installation: Installation,
         repositories: Option<repository::Map>,
     ) -> Result<Client, Error> {
         let name = client_name.to_string();
+
         let config = config::Manager::system(&installation.root, "moss");
         let install_db = db::meta::Database::new(installation.db_path("install").to_str().unwrap_or_default())?;
         let state_db = db::state::Database::new(installation.db_path("state").to_str().unwrap_or_default())?;

--- a/moss/src/client/mod.rs
+++ b/moss/src/client/mod.rs
@@ -71,6 +71,7 @@ pub struct ClientBuilder {
     client_name: String,
     installation: Installation,
     repositories: Option<repository::Map>,
+    system_model_path: Option<PathBuf>,
     blit_root: Option<PathBuf>,
 }
 
@@ -81,6 +82,7 @@ impl ClientBuilder {
             client_name: client_name.to_string(),
             installation,
             repositories: None,
+            system_model_path: None,
             blit_root: None,
         }
     }
@@ -88,6 +90,12 @@ impl ClientBuilder {
     /// Set the repositories
     pub fn repositories(mut self, repositories: repository::Map) -> ClientBuilder {
         self.repositories = Some(repositories);
+        self
+    }
+
+    /// Set system model path
+    pub fn system_model_path(mut self, path: impl Into<PathBuf>) -> ClientBuilder {
+        self.system_model_path = Some(path.into());
         self
     }
 
@@ -106,7 +114,12 @@ impl ClientBuilder {
 
     /// Build the [`Client`]
     pub fn build(self) -> Result<Client, Error> {
-        let mut client = Client::build(self.client_name, self.installation, self.repositories)?;
+        let mut client = Client::build(
+            self.client_name,
+            self.installation,
+            self.repositories,
+            self.system_model_path,
+        )?;
         if let Some(blit_root) = self.blit_root {
             client = client.ephemeral(blit_root)?;
         }
@@ -137,16 +150,22 @@ pub struct Client {
 impl Client {
     /// Construct a new Client for the given [`Installation`]
     pub fn new(client_name: impl ToString, installation: Installation) -> Result<Client, Error> {
-        Self::build(client_name.to_string(), installation, None)
+        Self::build(client_name.to_string(), installation, None, None)
     }
 
     /// Build a functioning Client for the given [`Installation`] and repositories
     fn build(
         client_name: String,
-        installation: Installation,
+        mut installation: Installation,
         repositories: Option<repository::Map>,
+        system_model_path: Option<PathBuf>,
     ) -> Result<Client, Error> {
         let name = client_name.to_string();
+
+        if let Some(path) = system_model_path {
+            installation.system_model =
+                Some(system_model::load(&path)?.ok_or(Error::ImportSystemModelDoesntExist(path.to_owned()))?);
+        }
 
         let config = config::Manager::system(&installation.root, "moss");
         let install_db = db::meta::Database::new(installation.db_path("install").to_str().unwrap_or_default())?;
@@ -196,8 +215,8 @@ impl Client {
     }
 
     /// Perform a sync
-    pub fn sync(&mut self, import: Option<&Path>, yes: bool, simulate: bool) -> Result<sync::Timing, Error> {
-        sync(self, import, yes, simulate).map_err(|error| Error::Sync(Box::new(error)))
+    pub fn sync(&mut self, yes: bool, simulate: bool) -> Result<sync::Timing, Error> {
+        sync(self, yes, simulate).map_err(|error| Error::Sync(Box::new(error)))
     }
 
     /// Transition to an ephemeral client that doesn't record state changes
@@ -1500,4 +1519,6 @@ pub enum Error {
     Fetch(#[source] Box<fetch::Error>),
     #[error("sync")]
     Sync(#[source] Box<sync::Error>),
+    #[error("system model doesn't exist at {0:?}")]
+    ImportSystemModelDoesntExist(PathBuf),
 }

--- a/moss/src/client/mod.rs
+++ b/moss/src/client/mod.rs
@@ -481,6 +481,15 @@ impl Client {
         record_system_model(&self.installation.staging_dir(), system_model)?;
 
         create_root_links(&self.installation.isolation_dir())?;
+
+        // The container running triggers expects /etc to exist
+        let root_etc = self.installation.root.join("etc");
+        fs::create_dir_all(root_etc)?;
+
+        let isolation_etc = self.installation.isolation_dir().join("etc");
+        fs::create_dir_all(isolation_etc)?;
+
+        // Apply transaction triggers
         Self::apply_triggers(TriggerScope::Transaction(&self.installation, &self.scope), &fstree)?;
 
         // Staging is only used with [`Scope::Stateful`]
@@ -513,6 +522,7 @@ impl Client {
         create_root_links(blit_root)?;
         create_root_links(&self.installation.isolation_dir())?;
 
+        // The container running triggers expects /etc to exist
         let etc = blit_root.join("etc");
         fs::create_dir_all(etc)?;
 

--- a/moss/src/client/mod.rs
+++ b/moss/src/client/mod.rs
@@ -76,17 +76,6 @@ pub struct ClientBuilder {
 }
 
 impl ClientBuilder {
-    /// Construct a new ClientBuilder for the given [`Installation`]
-    pub fn new(client_name: impl ToString, installation: Installation) -> ClientBuilder {
-        ClientBuilder {
-            client_name: client_name.to_string(),
-            installation,
-            repositories: None,
-            system_model_path: None,
-            blit_root: None,
-        }
-    }
-
     /// Set the repositories
     pub fn repositories(mut self, repositories: repository::Map) -> ClientBuilder {
         self.repositories = Some(repositories);
@@ -113,13 +102,42 @@ impl ClientBuilder {
     }
 
     /// Build the [`Client`]
-    pub fn build(self) -> Result<Client, Error> {
-        let mut client = Client::build(
-            self.client_name,
-            self.installation,
-            self.repositories,
-            self.system_model_path,
-        )?;
+    pub fn build(mut self) -> Result<Client, Error> {
+        if let Some(path) = self.system_model_path {
+            self.installation.system_model =
+                Some(system_model::load(&path)?.ok_or(Error::ImportSystemModelDoesntExist(path.to_owned()))?);
+        }
+
+        let config = config::Manager::system(&self.installation.root, "moss");
+        let install_db = db::meta::Database::new(self.installation.db_path("install").to_str().unwrap_or_default())?;
+        let state_db = db::state::Database::new(self.installation.db_path("state").to_str().unwrap_or_default())?;
+        let layout_db = db::layout::Database::new(self.installation.db_path("layout").to_str().unwrap_or_default())?;
+
+        let repositories = if let Some(repos) = self.repositories {
+            repository::Manager::explicit(&self.client_name, repos, self.installation.clone())?
+        } else if let Some(system_model) = &self.installation.system_model {
+            repository::Manager::explicit(
+                &self.client_name,
+                system_model.repositories.clone(),
+                self.installation.clone(),
+            )?
+        } else {
+            repository::Manager::system(config.clone(), self.installation.clone())?
+        };
+
+        let registry = build_registry(&self.installation, &repositories, &install_db, &state_db)?;
+
+        let mut client = Client {
+            config,
+            installation: self.installation,
+            repositories,
+            registry,
+            install_db,
+            state_db,
+            layout_db,
+            scope: Scope::Stateful,
+        };
+
         if let Some(blit_root) = self.blit_root {
             client = client.ephemeral(blit_root)?;
         }
@@ -148,50 +166,20 @@ pub struct Client {
 }
 
 impl Client {
-    /// Construct a new Client for the given [`Installation`]
-    pub fn new(client_name: impl ToString, installation: Installation) -> Result<Client, Error> {
-        Self::build(client_name.to_string(), installation, None, None)
+    /// Construct a new ClientBuilder for the given [`Installation`]
+    pub fn builder(client_name: impl ToString, installation: Installation) -> ClientBuilder {
+        ClientBuilder {
+            client_name: client_name.to_string(),
+            installation,
+            repositories: None,
+            system_model_path: None,
+            blit_root: None,
+        }
     }
 
-    /// Build a functioning Client for the given [`Installation`] and repositories
-    fn build(
-        client_name: String,
-        mut installation: Installation,
-        repositories: Option<repository::Map>,
-        system_model_path: Option<PathBuf>,
-    ) -> Result<Client, Error> {
-        let name = client_name.to_string();
-
-        if let Some(path) = system_model_path {
-            installation.system_model =
-                Some(system_model::load(&path)?.ok_or(Error::ImportSystemModelDoesntExist(path.to_owned()))?);
-        }
-
-        let config = config::Manager::system(&installation.root, "moss");
-        let install_db = db::meta::Database::new(installation.db_path("install").to_str().unwrap_or_default())?;
-        let state_db = db::state::Database::new(installation.db_path("state").to_str().unwrap_or_default())?;
-        let layout_db = db::layout::Database::new(installation.db_path("layout").to_str().unwrap_or_default())?;
-
-        let repositories = if let Some(repos) = repositories {
-            repository::Manager::explicit(&name, repos, installation.clone())?
-        } else if let Some(system_model) = &installation.system_model {
-            repository::Manager::explicit(&name, system_model.repositories.clone(), installation.clone())?
-        } else {
-            repository::Manager::system(config.clone(), installation.clone())?
-        };
-
-        let registry = build_registry(&installation, &repositories, &install_db, &state_db)?;
-
-        Ok(Client {
-            config,
-            installation,
-            repositories,
-            registry,
-            install_db,
-            state_db,
-            layout_db,
-            scope: Scope::Stateful,
-        })
+    /// Construct a new Client for the given [`Installation`]
+    pub fn new(client_name: impl ToString, installation: Installation) -> Result<Client, Error> {
+        Self::builder(client_name.to_string(), installation).build()
     }
 
     /// Returns `true` if this is an ephemeral client

--- a/moss/src/client/sync.rs
+++ b/moss/src/client/sync.rs
@@ -3,7 +3,6 @@
 
 use std::{
     collections::BTreeSet,
-    path::{Path, PathBuf},
     time::{Duration, Instant},
 };
 
@@ -20,15 +19,12 @@ use crate::{
     system_model,
 };
 
-pub fn sync(client: &Client, import: Option<&Path>, yes: bool, simulate: bool) -> Result<Timing, Error> {
+pub fn sync(client: &Client, yes: bool, simulate: bool) -> Result<Timing, Error> {
     let mut timing = Timing::default();
     let mut instant = Instant::now();
 
-    let system_model = if let Some(path) = import {
-        Some(system_model::load(path)?.ok_or(Error::ImportSystemModelDoesntExist(path.to_owned()))?)
-    } else {
-        client.installation.system_model.clone()
-    };
+    // Grab the system model from the installation
+    let system_model = client.installation.system_model.clone();
 
     // Grab all the existing installed packages
     let installed = client.registry.list_installed().collect::<Vec<_>>();
@@ -316,7 +312,4 @@ pub enum Error {
 
     #[error("load system model")]
     LoadSystemModel(#[from] system_model::LoadError),
-
-    #[error("system model doesn't exist at {0:?}")]
-    ImportSystemModelDoesntExist(PathBuf),
 }

--- a/moss/src/lib.rs
+++ b/moss/src/lib.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
-pub use self::client::Client;
+pub use self::client::{Client, ClientBuilder};
 pub use self::dependency::{Dependency, Provider};
 pub use self::installation::Installation;
 pub use self::package::Package;


### PR DESCRIPTION
This also adds `ClientBuilder` and modifies `Client::apply_stateful_blit` to make sure `/etc` exists before running triggers.

Tested locally and everything works as expected. `cargo test --all` also succeeds.

Fixes https://github.com/AerynOS/os-tools/issues/779