### PR TITLE
Boulder: Various improvements

### DIFF
--- a/boulder/data/macros/actions/autotools.yaml
+++ b/boulder/data/macros/actions/autotools.yaml
@@ -68,7 +68,14 @@ actions:
     - make:
         description: |
             Perform a `make` to build the current Makefile.
-            Tip: Add V=1 VERBOSE=1 after `%%make` in the recipe if you need a more verbose build.
+        command: |
+            make VERBOSE=1 -j "%(jobs)"
+        dependencies:
+            - binary(make)
+
+    - make_no_verbose:
+        description: |
+            Perform a `make` to build the current Makefile. This doesn't use the VERBOSE flag.
         command: |
             make -j "%(jobs)"
         dependencies:

--- a/boulder/data/macros/actions/golang.yaml
+++ b/boulder/data/macros/actions/golang.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
+actions:
+    - go_mod:
+        description: Downloads Golang dependencies
+        example: |
+            %go_mod
+        command: |
+          go mod download
+        dependencies:
+            - binary(go)

--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -125,17 +125,21 @@ defaultTuningGroups :
     - bindnow
     - build-id
     - compress-debug
+    - control-flow
     - debug
     - fat-lto
     - fortify
     - frame-pointer
     - harden
     - icf
+    - libstdc-assertions
     - lto
     - lto-errors
     - optimize
     - relr
     - symbolic
+    - thread-exceptions
+    - tls-gnu
     - version-allow-undefined
 
 tuning              :
@@ -196,7 +200,14 @@ tuning              :
 
     # Enable fortify
     - fortify:
-        enabled: fortify
+        options:
+            - lvl1:
+                enabled: fortify-lvl1
+            - lvl2:
+                enabled: fortify-lvl2
+            - lvl3:
+                enabled: fortify-lvl3
+        default: lvl3
 
     # Enable hardening
     - harden:
@@ -209,6 +220,18 @@ tuning              :
                 enabled: harden-lvl2
         disabled: harden-none
         default: lvl1
+
+    # Instrument control-flow architecture protection
+    - control-flow:
+        enabled: control-flow
+
+    # Enable libstdc++ assertions
+    - libstdc-assertions:
+        enabled: libstdc-assertions
+
+    # Enable protected thread cancellation handlers
+    - thread-exceptions:
+        enabled: thread-exceptions
 
     # Enable optimisation per given levels
     - optimize:
@@ -336,6 +359,10 @@ tuning              :
     - relr:
         enabled: relr
 
+    # Enable GNU2 TLS descriptors
+    - tls-gnu:
+        enabled: tls-gnu
+
     # Whether or not symbols in version scripts are allowed to be undefined
     - version-allow-undefined:
         enabled: version-allow-undefined
@@ -386,11 +413,21 @@ flags               :
         llvm:
             ld        : "-Wl,-Bsymbolic-non-weak-functions"
 
-    # Toggle fortify (ON)
-    - fortify:
-        c         : "-D_FORTIFY_SOURCE=2"
-        cxx       : "-D_FORTIFY_SOURCE=2"
-        f         : "-D_FORTIFY_SOURCE=2"
+    # Toggle fortify
+    - fortify-lvl1:
+        c         : "-Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=1"
+        cxx       : "-Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=1"
+        f         : "-Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=1"
+
+    - fortify-lvl2:
+        c         : "-Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=2"
+        cxx       : "-Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=2"
+        f         : "-Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=2"
+
+    - fortify-lvl3:
+        c         : "-Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3"
+        cxx       : "-Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3"
+        f         : "-Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3"
 
     # No hardening!
     - harden-none:
@@ -409,6 +446,24 @@ flags               :
         gnu:
             c         : "-fstack-protector-strong -fstack-clash-protection -fPIE --param ssp-buffer-size=4"
             cxx       : "-fstack-protector-strong -fstack-clash-protection -fPIE --param ssp-buffer-size=4"
+
+    # Instrument control-flow architecture protection (ON)
+    - control-flow:
+        c         : "-fcf-protection"
+        cxx       : "-fcf-protection"
+        f         : "-fcf-protection"
+
+    # Enable libstdc++ assertions (ON)
+    - libstdc-assertions:
+        c         : "-Wp,-D_GLIBCXX_ASSERTIONS"
+        cxx       : "-Wp,-D_GLIBCXX_ASSERTIONS"
+        f         : "-Wp,-D_GLIBCXX_ASSERTIONS"
+
+    # Enable protected thread cancellation handlers (ON)
+    - thread-exceptions:
+        c         : "-fexceptions"
+        cxx       : "-fexceptions"
+        f         : "-fexceptions"
 
     # Use section splitting, improves GC without lto only (OFF)
     - sections:
@@ -429,14 +484,14 @@ flags               :
         d         : "-O2"
         # opt-level=3 is common in the rust world so let that
         # be our generic opt case.
-        rust      : "-C opt-level=3 -C codegen-units=16"
+        rust      : "-C opt-level=3 -C codegen-units=1"
 
     # Optimize for size (OFF)
     - optimize-size:
         c     : "-Os"
         cxx   : "-Os"
         d     : "-Os"
-        rust  : "-C opt-level=s -C codegen-units=16"
+        rust  : "-C opt-level=s -C codegen-units=1"
         gnu:
             f : "-Os"
 
@@ -446,7 +501,7 @@ flags               :
         cxx       : "-O3"
         f         : "-O3"
         d         : "-O3"
-        rust      : "-C opt-level=3 -C codegen-units=16"
+        rust      : "-C opt-level=3 -C codegen-units=1"
 
     # Enable LTO optimisations (OFF)
     - lto-full:
@@ -675,6 +730,12 @@ flags               :
     # Toggle relr (ON)
     - relr:
         ld        : "-Wl,-z,pack-relative-relocs"
+
+    # Toggle gnu2 TLS descriptors (ON)
+    - tls-gnu:
+        c         : "-mtls-dialect=gnu2"
+        cxx       : "-mtls-dialect=gnu2"
+        f         : "-mtls-dialect=gnu2"
 
     # Allow undefined symbols in version scripts (ON)
     - version-allow-undefined:

--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -58,6 +58,7 @@ definitions:
     - gocachedir     : "%(compiler_go_cache)"
     - gomodcachedir  : "%(compiler_go_mod_cache)"
     - cargocachedir  : "%(compiler_cargo_cache)"
+    - zigcachedir    : "%(compiler_zig_cache)"
     - sccachedir     : "%(scompiler_cache)"
     - pkgconfigpath  : "%(libdir)/pkgconfig:/usr/share/pkgconfig"
 
@@ -115,6 +116,10 @@ actions              :
             test -z "$GOMODCACHE" && unset GOMODCACHE;
             CARGO_HOME="%(cargocachedir)"; export CARGO_HOME;
             test -z "$CARGO_HOME" && unset CARGO_HOME;
+            ZIG_GLOBAL_CACHE_DIR="%(zigcachedir)"; export ZIG_GLOBAL_CACHE_DIR;
+            test -z "$ZIG_GLOBAL_CACHE_DIR" && unset ZIG_GLOBAL_CACHE_DIR;
+            ZIG_LOCAL_CACHE_DIR="%(zigcachedir)"; export ZIG_LOCAL_CACHE_DIR;
+            test -z "$ZIG_LOCAL_CACHE_DIR" && unset ZIG_LOCAL_CACHE_DIR;
             SCCACHE_DIR="%(sccachedir)"; export SCCACHE_DIR;
             test -z "$SCCACHE_DIR" && unset SCCACHE_DIR;
             LANG="en_US.UTF-8"; export LANG

--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -99,6 +99,8 @@ actions              :
             RANLIB="%(ranlib)"; export RANLIB
             STRIP="%(strip)"; export STRIP
             PATH="%(path)"; export PATH
+            GOAMD64="%(goamd64_arch)"; export GOAMD64
+            test -z "$GOAMD64" && unset GOAMD64;
             CCACHE_DIR="%(ccachedir)"; export CCACHE_DIR;
             CCACHE_BASEDIR="%(workdir)"; export CCACHE_BASEDIR
             test -z "$CCACHE_DIR" && unset CCACHE_DIR;

--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -84,6 +84,7 @@ actions              :
             CGO_LDFLAGS="%(ldflags) -Wl,--no-gc-sections"; export CGO_LDFLAGS
             DFLAGS="%(dflags)"; export DFLAGS
             RUSTFLAGS="%(rustflags)"; export RUSTFLAGS
+            VALAFLAGS="%(valaflags)"; export VALAFLAGS
             CC="%(cc)"; export CC
             CXX="%(cxx)"; export CXX
             OBJC="%(objc)"; export OBJC
@@ -645,6 +646,7 @@ flags               :
         f         : "-g"
         d         : "-g -gc -d-debug"
         rust      : "-C debuginfo=2 -C split-debuginfo=off"
+        vala      : "-g"
         gnu:
             c         : "-g -feliminate-unused-debug-types -fasynchronous-unwind-tables"
             cxx       : "-g -feliminate-unused-debug-types -fasynchronous-unwind-tables"

--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -85,6 +85,7 @@ actions              :
             DFLAGS="%(dflags)"; export DFLAGS
             RUSTFLAGS="%(rustflags)"; export RUSTFLAGS
             VALAFLAGS="%(valaflags)"; export VALAFLAGS
+            GOFLAGS="%(goflags)"; export GOFLAGS
             CC="%(cc)"; export CC
             CXX="%(cxx)"; export CXX
             OBJC="%(objc)"; export OBJC
@@ -133,6 +134,8 @@ defaultTuningGroups :
     - fat-lto
     - fortify
     - frame-pointer
+    - golang-ldflags
+    - golang-modflags
     - harden
     - icf
     - libstdc-assertions
@@ -370,6 +373,15 @@ tuning              :
     - version-allow-undefined:
         enabled: version-allow-undefined
         disabled: version-no-undefined
+
+    # Enable default Golang ld flags
+    - golang-ldflags:
+        enabled: golang-ldflags
+
+    # Enable default Golang module handling
+    - golang-modflags:
+        enabled: golang-modflags
+
 flags               :
 
     # Needs overriding with -march/mtune values.
@@ -386,6 +398,7 @@ flags               :
         ld        : "-Wl,-O2,--gc-sections"
         d         : "-release -Hkeep-all-bodies -relocation-model=pic -wi"
         rust      : "-C strip=none"
+        go        : "-trimpath"
 
     - omit-frame-pointer:
         c         : "-fomit-frame-pointer -momit-leaf-frame-pointer"
@@ -441,14 +454,17 @@ flags               :
     - harden-lvl1:
         c         : "-fstack-protector --param ssp-buffer-size=32"
         cxx       : "-fstack-protector --param ssp-buffer-size=32"
+        go        : "-buildmode=pie"
 
     - harden-lvl2:
         llvm:
             c         : "-fstack-protector-strong -fstack-clash-protection -fPIE --param ssp-buffer-size=4"
             cxx       : "-fstack-protector-strong -fstack-clash-protection -fPIE --param ssp-buffer-size=4"
+            go        : "-buildmode=pie"
         gnu:
             c         : "-fstack-protector-strong -fstack-clash-protection -fPIE --param ssp-buffer-size=4"
             cxx       : "-fstack-protector-strong -fstack-clash-protection -fPIE --param ssp-buffer-size=4"
+            go        : "-buildmode=pie"
 
     # Instrument control-flow architecture protection (ON)
     - control-flow:
@@ -748,6 +764,14 @@ flags               :
     # Don't allow undefined symbols in version scripts (OFF)
     - version-no-undefined:
         ld        : "-Wl,--no-undefined-version"
+
+    # Enable module flags integrating with Boulder (ON)
+    - golang-modflags:
+        go        : "-mod=readonly -modcacherw"
+
+    # Enable linking to glibc (ON)
+    - golang-ldflags:
+        go        : "-ldflags=-linkmode=external"
 
 # Template packages
 packages          :

--- a/boulder/data/macros/arch/x86_64-v3x.yaml
+++ b/boulder/data/macros/arch/x86_64-v3x.yaml
@@ -13,6 +13,7 @@ definitions:
     - cpp            : "%(compiler_cpp)"
     - march          : x86-64-v3
     - mtune          : znver1
+    - goamd64_arch   : "v3"
 
 flags:
 

--- a/boulder/data/macros/arch/x86_64.yaml
+++ b/boulder/data/macros/arch/x86_64.yaml
@@ -15,6 +15,7 @@ definitions:
     - march          : x86-64-v2
     - mtune          : ivybridge
     - target_triple  : "x86_64-unknown-linux-gnu"
+    - goamd64_arch   : "v2"
 
 flags:
 

--- a/boulder/src/build/job/phase.rs
+++ b/boulder/src/build/job/phase.rs
@@ -165,11 +165,13 @@ impl Phase {
             parser.add_definition("compiler_go_cache", "/mason/gocache");
             parser.add_definition("compiler_go_mod_cache", "/mason/gomodcache");
             parser.add_definition("compiler_cargo_cache", "/mason/cargocache");
+            parser.add_definition("compiler_zig_cache", "/mason/zigcache");
             parser.add_definition("rustc_wrapper", "/usr/bin/sccache");
         } else {
             parser.add_definition("compiler_go_cache", "");
             parser.add_definition("compiler_go_mod_cache", "");
             parser.add_definition("compiler_cargo_cache", "");
+            parser.add_definition("compiler_zig_cache", "");
             parser.add_definition("rustc_wrapper", "");
         }
 

--- a/boulder/src/build/job/phase.rs
+++ b/boulder/src/build/job/phase.rs
@@ -379,6 +379,11 @@ fn add_tuning(
             .iter()
             .filter_map(|flag| flag.get(tuning::CompilerFlag::Rust, toolchain)),
     );
+    let valaflags = fmt_flags(
+        flags
+            .iter()
+            .filter_map(|flag| flag.get(tuning::CompilerFlag::Vala, toolchain)),
+    );
 
     if recipe.parsed.mold {
         cflags.push_str(" -fuse-ld=mold");
@@ -392,6 +397,7 @@ fn add_tuning(
     parser.add_definition("ldflags", ldflags);
     parser.add_definition("dflags", dflags);
     parser.add_definition("rustflags", rustflags);
+    parser.add_definition("valaflags", valaflags);
 
     Ok(())
 }

--- a/boulder/src/build/job/phase.rs
+++ b/boulder/src/build/job/phase.rs
@@ -384,6 +384,11 @@ fn add_tuning(
             .iter()
             .filter_map(|flag| flag.get(tuning::CompilerFlag::Vala, toolchain)),
     );
+    let goflags = fmt_flags(
+        flags
+            .iter()
+            .filter_map(|flag| flag.get(tuning::CompilerFlag::Go, toolchain)),
+    );
 
     if recipe.parsed.mold {
         cflags.push_str(" -fuse-ld=mold");
@@ -398,6 +403,7 @@ fn add_tuning(
     parser.add_definition("dflags", dflags);
     parser.add_definition("rustflags", rustflags);
     parser.add_definition("valaflags", valaflags);
+    parser.add_definition("goflags", goflags);
 
     Ok(())
 }

--- a/boulder/src/container.rs
+++ b/boulder/src/container.rs
@@ -24,6 +24,7 @@ where
     let gocache = paths.gocache();
     let gomodcache = paths.gomodcache();
     let cargocache = paths.cargocache();
+    let zigcache = paths.zigcache();
     let rustc_wrapper = paths.sccache();
     let recipe = paths.recipe();
     let ccache_conf = paths.ccache_config();
@@ -39,6 +40,7 @@ where
         .bind_rw(&gocache.host, &gocache.guest)
         .bind_rw(&gomodcache.host, &gomodcache.guest)
         .bind_rw(&cargocache.host, &cargocache.guest)
+        .bind_rw(&zigcache.host, &zigcache.guest)
         .bind_rw(&rustc_wrapper.host, &rustc_wrapper.guest)
         .bind_ro(&recipe.host, &recipe.guest)
         .bind_ro_if_exists(&ccache_conf.host, &ccache_conf.guest);

--- a/boulder/src/paths.rs
+++ b/boulder/src/paths.rs
@@ -59,6 +59,7 @@ impl Paths {
         util::ensure_dir_exists(&job.gocache().host)?;
         util::ensure_dir_exists(&job.gomodcache().host)?;
         util::ensure_dir_exists(&job.cargocache().host)?;
+        util::ensure_dir_exists(&job.zigcache().host)?;
         util::ensure_dir_exists(&job.sccache().host)?;
         util::ensure_dir_exists(&job.upstreams().host)?;
 
@@ -119,6 +120,13 @@ impl Paths {
         Mapping {
             host: self.host_root.join("cargocache"),
             guest: self.guest_root.join("cargocache"),
+        }
+    }
+
+    pub fn zigcache(&self) -> Mapping {
+        Mapping {
+            host: self.host_root.join("zigcache"),
+            guest: self.guest_root.join("zigcache"),
         }
     }
 

--- a/crates/stone_recipe/src/tuning.rs
+++ b/crates/stone_recipe/src/tuning.rs
@@ -85,6 +85,7 @@ pub enum CompilerFlag {
     F,
     D,
     Rust,
+    Vala,
     Ld,
 }
 
@@ -95,6 +96,7 @@ pub struct CompilerFlags {
     f: Option<String>,
     d: Option<String>,
     rust: Option<String>,
+    vala: Option<String>,
     ld: Option<String>,
 }
 
@@ -106,6 +108,7 @@ impl CompilerFlags {
             CompilerFlag::F => self.f.as_deref(),
             CompilerFlag::D => self.d.as_deref(),
             CompilerFlag::Rust => self.rust.as_deref(),
+            CompilerFlag::Vala => self.vala.as_deref(),
             CompilerFlag::Ld => self.ld.as_deref(),
         }
     }

--- a/crates/stone_recipe/src/tuning.rs
+++ b/crates/stone_recipe/src/tuning.rs
@@ -86,6 +86,7 @@ pub enum CompilerFlag {
     D,
     Rust,
     Vala,
+    Go,
     Ld,
 }
 
@@ -97,6 +98,7 @@ pub struct CompilerFlags {
     d: Option<String>,
     rust: Option<String>,
     vala: Option<String>,
+    go: Option<String>,
     ld: Option<String>,
 }
 
@@ -109,6 +111,7 @@ impl CompilerFlags {
             CompilerFlag::D => self.d.as_deref(),
             CompilerFlag::Rust => self.rust.as_deref(),
             CompilerFlag::Vala => self.vala.as_deref(),
+            CompilerFlag::Go => self.go.as_deref(),
             CompilerFlag::Ld => self.ld.as_deref(),
         }
     }

--- a/test/base.yml
+++ b/test/base.yml
@@ -70,6 +70,7 @@ actions              :
             LDFLAGS="%(ldflags)"; export LDFLAGS
             CGO_LDFLAGS="%(ldflags) -Wl,--no-gc-sections"; export CGO_LDFLAGS
             RUSTFLAGS="%(rustflags)"; export RUSTFLAGS
+            VALAFLAGS="%(valaflags)"; export VALAFLAGS
             CC="%(cc)"; export CC
             CXX="%(cxx)"; export CXX
             OBJC="%(objc)"; export OBJC
@@ -437,6 +438,7 @@ flags               :
     - debug-std:
         c         : "-g -feliminate-unused-debug-types -fasynchronous-unwind-tables"
         cxx       : "-g -feliminate-unused-debug-types -fasynchronous-unwind-tables"
+        vala      : "-g"
 
     # Toggle fast math (OFF)
     - math:

--- a/test/base.yml
+++ b/test/base.yml
@@ -71,6 +71,7 @@ actions              :
             CGO_LDFLAGS="%(ldflags) -Wl,--no-gc-sections"; export CGO_LDFLAGS
             RUSTFLAGS="%(rustflags)"; export RUSTFLAGS
             VALAFLAGS="%(valaflags)"; export VALAFLAGS
+            GOFLAGS="%(goflags)"; export GOFLAGS
             CC="%(cc)"; export CC
             CXX="%(cxx)"; export CXX
             OBJC="%(objc)"; export OBJC


### PR DESCRIPTION
Note that using a single codegen unit instead of the (default) 16 can make compiles painfully slow.