### PR TITLE
Use snafu over thiserror in boulder::package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "similar",
+ "snafu",
  "stone",
  "stone_recipe 0.26.1",
  "strum",

--- a/boulder/Cargo.toml
+++ b/boulder/Cargo.toml
@@ -48,6 +48,7 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 sha2.workspace = true
 similar.workspace = true
+snafu.workspace = true
 strum.workspace = true
 thiserror.workspace = true
 thread-priority.workspace = true

--- a/boulder/src/package/collect.rs
+++ b/boulder/src/package/collect.rs
@@ -12,8 +12,8 @@ use astr::AStr;
 use fs_err as fs;
 use glob::Pattern;
 use nix::libc::{S_IFDIR, S_IRGRP, S_IROTH, S_IRWXU, S_IXGRP, S_IXOTH};
+use snafu::{ResultExt as _, Snafu};
 use stone::{StoneDigestWriter, StoneDigestWriterHasher, StonePayloadLayoutFile, StonePayloadLayoutRecord};
-use thiserror::Error;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Rule {
@@ -71,7 +71,7 @@ impl Collector {
 
     /// Produce a [`PathInfo`] from the provided [`Path`]
     pub fn path(&self, path: &Path, hasher: &mut StoneDigestWriterHasher) -> Result<PathInfo, Error> {
-        let metadata = fs::metadata(path)?;
+        let metadata = fs::metadata(path).context(IoSnafu)?;
         self.path_with_metadata(path.to_path_buf(), &metadata, hasher)
     }
 
@@ -99,12 +99,15 @@ impl Collector {
         let mut paths = vec![];
 
         let dir = subdir.as_ref().map(|t| t.0.as_path()).unwrap_or(&self.root);
-        let mut entries: Vec<_> = fs::read_dir(dir)?.collect::<Result<Vec<_>, _>>()?;
+        let mut entries: Vec<_> = fs::read_dir(dir)
+            .context(IoSnafu)?
+            .collect::<Result<Vec<_>, _>>()
+            .context(IoSnafu)?;
 
         entries.sort_by_key(|entry| entry.file_name());
 
         for entry in entries {
-            let metadata = entry.metadata()?;
+            let metadata = entry.metadata().context(IoSnafu)?;
 
             let host_path = entry.path();
 
@@ -162,7 +165,7 @@ impl PathInfo {
     }
 
     pub fn restat(&mut self, hasher: &mut StoneDigestWriterHasher) -> Result<(), Error> {
-        let metadata = fs::metadata(&self.path)?;
+        let metadata = fs::metadata(&self.path).context(IoSnafu)?;
         self.layout = layout_from_metadata(&self.path, &self.target_path, &metadata, hasher)?;
         self.size = metadata.size();
         Ok(())
@@ -215,7 +218,7 @@ fn layout_from_metadata(
         mode: metadata.mode(),
         tag: 0,
         file: if file_type.is_symlink() {
-            let source = fs::read_link(path)?;
+            let source = fs::read_link(path).context(IoSnafu)?;
 
             StonePayloadLayoutFile::Symlink(source.to_string_lossy().into(), target)
         } else if file_type.is_dir() {
@@ -232,11 +235,11 @@ fn layout_from_metadata(
             hasher.reset();
 
             let mut digest_writer = StoneDigestWriter::new(io::sink(), hasher);
-            let mut file = fs::File::open(path)?;
+            let mut file = fs::File::open(path).context(IoSnafu)?;
 
             // Copy bytes to null sink so we don't
             // explode memory
-            io::copy(&mut file, &mut digest_writer)?;
+            io::copy(&mut file, &mut digest_writer).context(IoSnafu)?;
 
             let hash = hasher.digest128();
 
@@ -245,10 +248,10 @@ fn layout_from_metadata(
     })
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Snafu)]
 pub enum Error {
-    #[error("no matching path rule")]
+    #[snafu(display("no matching path rule"))]
     NoMatchingRule,
-    #[error("io")]
-    Io(#[from] io::Error),
+    #[snafu(display("io"))]
+    Io { source: io::Error },
 }

--- a/boulder/src/package/emit.rs
+++ b/boulder/src/package/emit.rs
@@ -11,8 +11,8 @@ use fs_err::{self as fs, File};
 use itertools::Itertools;
 use moss::{Dependency, Provider, package::Meta, util};
 use regex::Regex;
+use snafu::{ResultExt, Snafu};
 use stone::{StoneHeaderV1FileType, StoneWriteError, StoneWriter};
-use thiserror::Error;
 use tui::{ProgressBar, ProgressStyle, Styled};
 
 use self::manifest::Manifest;
@@ -163,9 +163,9 @@ pub fn emit(paths: &Paths, recipe: &Recipe, packages: &[Package<'_>]) -> Result<
         // of manifest files
         emit_manifests = false;
 
-        match manifest.verify(guest_path)? {
+        match manifest.verify(guest_path).context(ManifestSnafu)? {
             manifest::Verification::Mismatch => {
-                return Err(Error::VerificationMismatch(host_path.to_owned()));
+                return VerificationMismatchSnafu { host_path }.fail();
             }
             manifest::Verification::HashMatch { hash } => {
                 println!(
@@ -191,8 +191,8 @@ pub fn emit(paths: &Paths, recipe: &Recipe, packages: &[Package<'_>]) -> Result<
     }
 
     if emit_manifests {
-        manifest.write_binary()?;
-        manifest.write_json()?;
+        manifest.write_binary().context(ManifestSnafu)?;
+        manifest.write_json().context(ManifestSnafu)?;
     }
 
     println!();
@@ -231,17 +231,19 @@ fn emit_package(paths: &Paths, package: &Package<'_>) -> Result<(), Error> {
     // Output file to artefacts directory
     let out_path = paths.artefacts().guest.join(&filename);
     if out_path.exists() {
-        fs::remove_file(&out_path)?;
+        fs::remove_file(&out_path).context(IoSnafu)?;
     }
-    let mut out_file = File::create(out_path)?;
+    let mut out_file = File::create(out_path).context(IoSnafu)?;
 
     // Create stone binary writer
-    let mut writer = StoneWriter::new(&mut out_file, StoneHeaderV1FileType::Binary)?;
+    let mut writer = StoneWriter::new(&mut out_file, StoneHeaderV1FileType::Binary).context(StoneBinaryWriterSnafu)?;
 
     // Add metadata
     {
         let meta = package.meta();
-        writer.add_payload(meta.to_stone_payload().as_slice())?;
+        writer
+            .add_payload(meta.to_stone_payload().as_slice())
+            .context(StoneBinaryWriterSnafu)?;
     }
 
     // Add layouts
@@ -253,7 +255,7 @@ fn emit_package(paths: &Paths, package: &Package<'_>) -> Result<(), Error> {
             .map(|p| p.layout.clone())
             .collect::<Vec<_>>();
         if !layouts.is_empty() {
-            writer.add_payload(layouts.as_slice())?;
+            writer.add_payload(layouts.as_slice()).context(StoneBinaryWriterSnafu)?;
         }
     }
 
@@ -265,27 +267,31 @@ fn emit_package(paths: &Paths, package: &Package<'_>) -> Result<(), Error> {
             .read(true)
             .append(true)
             .create(true)
-            .open(&temp_content_path)?;
+            .open(&temp_content_path)
+            .context(IoSnafu)?;
 
         // Convert to content writer using pledged size = total size of all files
-        let mut writer =
-            writer.with_content(&mut temp_content, Some(total_file_size), util::num_cpus().get() as u32)?;
+        let mut writer = writer
+            .with_content(&mut temp_content, Some(total_file_size), util::num_cpus().get() as u32)
+            .context(StoneBinaryWriterSnafu)?;
 
         for info in files {
-            let file = File::open(&info.path)?;
-            writer.add_content(&mut pb.wrap_read(&file))?;
+            let file = File::open(&info.path).context(IoSnafu)?;
+            writer
+                .add_content(&mut pb.wrap_read(&file))
+                .context(StoneBinaryWriterSnafu)?;
         }
 
         // Finalize & flush
-        writer.finalize()?;
-        out_file.flush()?;
+        writer.finalize().context(StoneBinaryWriterSnafu)?;
+        out_file.flush().context(IoSnafu)?;
 
         // Remove temp content file
-        fs::remove_file(temp_content_path)?;
+        fs::remove_file(temp_content_path).context(IoSnafu)?;
     } else {
         // Finalize & flush
-        writer.finalize()?;
-        out_file.flush()?;
+        writer.finalize().context(StoneBinaryWriterSnafu)?;
+        out_file.flush().context(IoSnafu)?;
     }
 
     pb.suspend(|| println!("{} {filename}", "Emitted".green()));
@@ -294,14 +300,14 @@ fn emit_package(paths: &Paths, package: &Package<'_>) -> Result<(), Error> {
     Ok(())
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Snafu)]
 pub enum Error {
-    #[error("stone binary writer")]
-    StoneBinaryWriter(#[from] StoneWriteError),
-    #[error("manifest")]
-    Manifest(#[from] manifest::Error),
-    #[error("io")]
-    Io(#[from] io::Error),
-    #[error("Built manifest does not match verification manifest {0:?}")]
-    VerificationMismatch(PathBuf),
+    #[snafu(display("stone binary writer"))]
+    StoneBinaryWriter { source: StoneWriteError },
+    #[snafu(display("manifest"))]
+    Manifest { source: manifest::Error },
+    #[snafu(display("io"))]
+    Io { source: io::Error },
+    #[snafu(display("Built manifest does not match verification manifest {host_path:?}"))]
+    VerificationMismatch { host_path: PathBuf },
 }

--- a/boulder/src/package/emit/manifest.rs
+++ b/boulder/src/package/emit/manifest.rs
@@ -12,9 +12,9 @@ use moss::{
     package::{Meta, MissingMetaFieldError},
     util,
 };
+use snafu::{ResultExt, Snafu};
 use stone::{StoneDecodedPayload, StoneReadError, StoneWriteError};
 use tempfile::NamedTempFile;
-use thiserror::Error;
 
 use crate::{Architecture, Paths, Recipe};
 
@@ -59,9 +59,10 @@ impl<'a> Manifest<'a> {
     }
 
     pub fn write_binary(&self) -> Result<(), Error> {
-        let mut output = fs::File::create(self.output_dir.join(format!("manifest.{}.bin", self.arch)))?;
+        let mut output =
+            fs::File::create(self.output_dir.join(format!("manifest.{}.bin", self.arch))).context(IoSnafu)?;
 
-        binary::write(&mut output, &self.packages, &self.build_deps)
+        binary::write(&mut output, &self.packages, &self.build_deps).context(StoneWriterSnafu)
     }
 
     pub fn write_json(&self) -> Result<(), Error> {
@@ -84,11 +85,11 @@ impl<'a> Manifest<'a> {
     pub fn verify(&self, compare_to: &Path) -> Result<Verification, Error> {
         // Write the current manifest to a temp file & hash it
         let (current_hash, mut current_temp_file) = {
-            let mut temp_file = NamedTempFile::with_prefix("boulder-")?;
+            let mut temp_file = NamedTempFile::with_prefix("boulder-").context(IoSnafu)?;
 
             let mut writer = util::Sha256Wrapper::new(&mut temp_file);
 
-            binary::write(&mut writer, &self.packages, &self.build_deps)?;
+            binary::write(&mut writer, &self.packages, &self.build_deps).context(StoneWriterSnafu)?;
 
             let hash = writer.finalize();
 
@@ -97,9 +98,9 @@ impl<'a> Manifest<'a> {
 
         // Get the comparison hash & file
         let (compare_to_hash, mut compare_to_file) = {
-            let mut file = fs::File::open(compare_to).map_err(Error::OpenManifest)?;
+            let mut file = fs::File::open(compare_to).context(OpenManifestSnafu)?;
 
-            let hash = util::sha256_hash(&mut file).map_err(Error::HashManifest)?;
+            let hash = util::sha256_hash(&mut file).context(HashManifestSnafu)?;
 
             (hash, file)
         };
@@ -113,15 +114,16 @@ impl<'a> Manifest<'a> {
         #[allow(clippy::disallowed_types)] // needed to accept either fs_err::File or NamedTempFile
         let extract_metas = |reader: &mut std::fs::File| {
             // Reset seek position to read stone payloads
-            reader.seek(SeekFrom::Start(0))?;
+            reader.seek(SeekFrom::Start(0)).context(IoSnafu)?;
 
-            let payloads = util::stone_payloads(reader).map_err(Error::ReadStonePayloads)?;
+            let payloads = util::stone_payloads(reader).context(ReadStonePayloadsSnafu)?;
 
             let metas = payloads
                 .iter()
                 .filter_map(StoneDecodedPayload::meta)
                 .map(|payload| Meta::from_stone_payload(&payload.body).map(OrderedMeta))
-                .collect::<Result<BTreeSet<_>, _>>()?;
+                .collect::<Result<BTreeSet<_>, _>>()
+                .context(ManifestMissingMetaFieldSnafu)?;
 
             Ok(metas) as Result<BTreeSet<_>, Error>
         };
@@ -147,22 +149,22 @@ pub enum Verification {
     ContentMatch,
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Snafu)]
 pub enum Error {
-    #[error("stone binary writer")]
-    StoneWriter(#[from] StoneWriteError),
-    #[error("encode json")]
-    Json(#[from] serde_json::Error),
-    #[error("io")]
-    Io(#[from] io::Error),
-    #[error("open manifest file")]
-    OpenManifest(#[source] io::Error),
-    #[error("sha256 hash manifest")]
-    HashManifest(#[source] io::Error),
-    #[error("read stone payloads")]
-    ReadStonePayloads(#[source] StoneReadError),
-    #[error("manifest missing meta field")]
-    ManifestMissingMetaField(#[from] MissingMetaFieldError),
+    #[snafu(display("stone binary writer"))]
+    StoneWriter { source: StoneWriteError },
+    #[snafu(display("encode json"))]
+    Json { source: serde_json::Error },
+    #[snafu(display("io"))]
+    Io { source: io::Error },
+    #[snafu(display("open manifest file"))]
+    OpenManifest { source: io::Error },
+    #[snafu(display("sha256 hash manifest"))]
+    HashManifest { source: io::Error },
+    #[snafu(display("read stone payloads"))]
+    ReadStonePayloads { source: StoneReadError },
+    #[snafu(display("manifest missing meta field"))]
+    ManifestMissingMetaField { source: MissingMetaFieldError },
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/boulder/src/package/emit/manifest/binary.rs
+++ b/boulder/src/package/emit/manifest/binary.rs
@@ -5,17 +5,17 @@ use std::{collections::BTreeSet, io::Write};
 
 use moss::Dependency;
 use stone::{
-    StoneHeaderV1FileType, StonePayloadMetaPrimitive, StonePayloadMetaRecord, StonePayloadMetaTag, StoneWriter,
+    StoneHeaderV1FileType, StonePayloadMetaPrimitive, StonePayloadMetaRecord, StonePayloadMetaTag, StoneWriteError,
+    StoneWriter,
 };
 
-use super::Error;
 use crate::package::emit::Package;
 
 pub fn write<W: Write>(
     output: &mut W,
     packages: &BTreeSet<&Package<'_>>,
     build_deps: &BTreeSet<String>,
-) -> Result<(), Error> {
+) -> Result<(), StoneWriteError> {
     let mut writer = StoneWriter::new(output, StoneHeaderV1FileType::BuildManifest)?;
 
     // Add each package

--- a/boulder/src/package/emit/manifest/json.rs
+++ b/boulder/src/package/emit/manifest/json.rs
@@ -11,8 +11,9 @@ use fs_err::File;
 use itertools::Itertools;
 use regex::Regex;
 use serde::Serialize;
+use snafu::ResultExt;
 
-use super::Error;
+use super::{Error, IoSnafu, JsonSnafu};
 use crate::{Recipe, package::emit};
 
 pub fn write(
@@ -90,18 +91,19 @@ pub fn write(
         source_version: recipe.parsed.source.version.clone(),
     };
 
-    let mut file = File::create(path)?;
+    let mut file = File::create(path).context(IoSnafu)?;
 
     writeln!(
         &mut file,
         "/** Human readable report. This is not consumed by boulder */"
-    )?;
+    )
+    .context(IoSnafu)?;
 
     let mut serializer =
         serde_json::Serializer::with_formatter(&mut file, serde_json::ser::PrettyFormatter::with_indent(b"\t"));
-    content.serialize(&mut serializer)?;
+    content.serialize(&mut serializer).context(JsonSnafu)?;
 
-    writeln!(&mut file)?;
+    writeln!(&mut file).context(IoSnafu)?;
 
     Ok(())
 }


### PR DESCRIPTION
Slooowly converting everything over. No cleanups this time, just straight-up conversion of thiserror to snafu. Doesn't mean that these error types are good as-is, I'm just not particularily 'inspired' right now – killing time bc. I can't sleep yet as I slept through half the day.