### PR TITLE
Move package metadata right after [package] sections

### DIFF
--- a/libstone/Cargo.toml
+++ b/libstone/Cargo.toml
@@ -7,6 +7,17 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
+[package.metadata.capi.header]
+name = "stone"
+subdirectory = false
+
+[package.metadata.capi.pkg_config]
+name = "libstone"
+filename = "libstone"
+
+[package.metadata.capi.library]
+name = "stone"
+
 [lib]
 name = "stone"
 crate-type = ["cdylib", "staticlib"]
@@ -22,14 +33,3 @@ strum.workspace = true
 
 [build-dependencies]
 cbindgen.workspace = true
-
-[package.metadata.capi.header]
-name = "stone"
-subdirectory = false
-
-[package.metadata.capi.pkg_config]
-name = "libstone"
-filename = "libstone"
-
-[package.metadata.capi.library]
-name = "stone"

--- a/moss/Cargo.toml
+++ b/moss/Cargo.toml
@@ -7,6 +7,10 @@ edition.workspace = true
 version.workspace = true
 rust-version.workspace = true
 
+[package.metadata.cargo-machete]
+# Needed for unixepoch() in src/db/state/migrations/2025-03-04-201550_init/up.sql
+ignored = ["libsqlite3-sys"]
+
 [features]
 testing = []
 
@@ -61,10 +65,6 @@ astr = { workspace = true, features = ["diesel"] }
 moss = { path = ".", features = ["testing"] }
 
 tempfile.workspace = true
-
-[package.metadata.cargo-machete]
-# Needed for unixepoch() in src/db/state/migrations/2025-03-04-201550_init/up.sql
-ignored = ["libsqlite3-sys"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
… in Cargo.toml files. This fixes warnings from my TOML language server.