### PR TITLE
moss: Fix repo refresh for system model

### DIFF
--- a/moss/src/client/mod.rs
+++ b/moss/src/client/mod.rs
@@ -237,9 +237,9 @@ impl Client {
     /// Reload all configured repositories and refreshes their index file, then update
     /// registry with all active repositories.
     pub async fn refresh_repositories(&mut self) -> Result<(), Error> {
-        // Reload manager if not explicit to pickup config changes
+        // Reload manager if config sourced to pickup config changes
         // then refresh indexes
-        if !self.repositories.is_explicit() {
+        if self.repositories.is_config_source() {
             self.repositories =
                 repository::Manager::with_config_manager(self.config.clone(), self.installation.clone())?;
         };

--- a/moss/src/repository/manager.rs
+++ b/moss/src/repository/manager.rs
@@ -57,8 +57,8 @@ pub struct Manager {
 }
 
 impl Manager {
-    pub fn is_explicit(&self) -> bool {
-        matches!(*self.source, Source::Explicit { .. })
+    pub fn is_config_source(&self) -> bool {
+        matches!(*self.source, Source::ConfigManager { .. })
     }
 
     /// Create a [`Manager`] for the supplied [`Installation`] using repositories loaded


### PR DESCRIPTION
Users with an active `/etc/moss/system-model.kdl` have reported that `sudo moss sync -u` doesn't work as expected.

Until this PR lands, the workaround is to do a `sudo moss repo update` and then do a `sudo moss sync` as separate commands.