### PR TITLE
Improve trigger logging

### DIFF
--- a/crates/triggers/src/format.rs
+++ b/crates/triggers/src/format.rs
@@ -5,7 +5,7 @@
 // but we don't Ord or Hash off that field
 #![allow(clippy::mutable_key_type)]
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, fmt};
 
 use fnmatch::Pattern;
 use serde::Deserialize;
@@ -24,6 +24,28 @@ pub enum PathKind {
 pub enum Handler {
     Run { run: String, args: Vec<String> },
     Delete { delete: Vec<String> },
+}
+
+impl fmt::Display for Handler {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let args = match self {
+            Handler::Run { run, args } => {
+                f.write_str(run)?;
+                args
+            }
+            Handler::Delete { delete } => {
+                f.write_str("rm --")?;
+                delete
+            }
+        };
+
+        // Note: No shell quoting for simplicity.
+        // Could use the shell-quote crate if we wanted to be more correct.
+        for arg in args {
+            write!(f, " {arg}")?;
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/moss/src/client/mod.rs
+++ b/moss/src/client/mod.rs
@@ -488,17 +488,13 @@ impl Client {
         for (i, trigger) in progress.wrap_iter(triggers.iter()).enumerate() {
             trigger.execute()?;
 
-            let trigger_command = match trigger.handler() {
-                triggers::format::Handler::Run { run, .. } => run.clone(),
-                triggers::format::Handler::Delete { .. } => "delete operation".to_owned(),
-            };
             info!(
                 progress = (i + 1) as f32 / triggers.len() as f32,
                 current = i + 1,
                 total = triggers.len(),
                 event_type = "progress_update",
-                "Executing {}",
-                trigger_command
+                "Executing `{}`",
+                trigger.handler()
             );
         }
 


### PR DESCRIPTION
I don't know if the `delete` field in `Handler::Delete` actually represents paths. It doesn't seem to be used in practice (`execute_trigger_directly` just has a `todo!()` branch for it).