### PR TITLE
Fix/moss hash checking

### DIFF
--- a/moss/src/client/cache.rs
+++ b/moss/src/client/cache.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use snafu::{OptionExt, ResultExt as _, Snafu, ensure};
-use stone::{StoneDecodedPayload, StonePayloadIndexRecord, StoneReadError};
+use stone::{StoneDecodedPayload, StoneDigestWriter, StoneDigestWriterHasher, StonePayloadIndexRecord, StoneReadError};
 use tracing::warn;
 use url::Url;
 
@@ -284,9 +284,21 @@ impl Download {
                 file.seek(SeekFrom::Start(idx.start))?;
                 let mut split_file = (&mut file).take(idx.end - idx.start);
 
+                let mut hasher = StoneDigestWriterHasher::new();
                 let mut output = File::create(&partial_path)?;
 
-                io::copy(&mut split_file, &mut output)?;
+                io::copy(&mut split_file, &mut StoneDigestWriter::new(&mut output, &mut hasher))?;
+
+                let digest = hasher.digest128();
+
+                ensure!(
+                    digest == idx.digest,
+                    FileUnpackHashMismatchSnafu {
+                        path: path.clone(),
+                        expected: idx.digest,
+                        actual: digest
+                    }
+                );
 
                 fs::rename(&partial_path, &path)?;
 
@@ -344,6 +356,12 @@ pub enum UnpackError {
     ReadStone { source: StoneReadError },
     #[snafu(context(false), display("io"))]
     Io { source: io::Error },
+    #[snafu(display("File unpack hash mismatch for {path:?}: expected {expected:02x}, got {actual:02x}"))]
+    FileUnpackHashMismatch {
+        path: PathBuf,
+        expected: u128,
+        actual: u128,
+    },
 }
 
 #[derive(Debug, Snafu)]

--- a/moss/src/client/cache.rs
+++ b/moss/src/client/cache.rs
@@ -13,9 +13,10 @@ use std::{
 
 use snafu::{OptionExt, ResultExt as _, Snafu, ensure};
 use stone::{StoneDecodedPayload, StonePayloadIndexRecord, StoneReadError};
+use tracing::warn;
 use url::Url;
 
-use crate::{Installation, package, request};
+use crate::{Installation, package, request, util};
 
 /// Synchronized set of assets that are currently being
 /// unpacked. Used to prevent unpacking the same asset
@@ -94,13 +95,36 @@ pub async fn fetch(
         fs::create_dir_all(parent).await?;
     }
 
-    if fs::try_exists(&destination_path).await? {
-        return Ok(Download {
-            id: meta.id().into(),
-            path: destination_path,
-            installation: installation.clone(),
-            was_cached: true,
-        });
+    let is_cached = async || -> Result<bool, FetchError> {
+        if fs::try_exists(&destination_path).await? {
+            // Ensure content is valid before trusting it
+            let mut file = fs::File::open(&destination_path).await?;
+            let actual_hash = util::sha256_hash_async(&mut file).await?;
+
+            return Ok(*hash == actual_hash);
+        }
+
+        Ok(false)
+    };
+
+    match is_cached().await {
+        Ok(true) => {
+            return Ok(Download {
+                id: meta.id().into(),
+                path: destination_path,
+                installation: installation.clone(),
+                was_cached: true,
+            });
+        }
+        Ok(false) => {}
+        // Always force re-download on any error checking
+        // cache validity
+        Err(err) => {
+            warn!(
+                error = format!("{err:#}"),
+                "Failed to verify cached download, will re-download"
+            );
+        }
     }
 
     let actual_hash = request::download_with_progress_and_sha256(url, &destination_path, |progress| {

--- a/moss/src/client/cache.rs
+++ b/moss/src/client/cache.rs
@@ -228,6 +228,7 @@ impl Download {
             .into_iter()
             .map(|idx| {
                 let path = asset_path(&self.installation, &format!("{:02x}", idx.digest));
+                let partial_path = path.with_added_extension("part");
 
                 // Acquire in-progress guard.
                 let _guard = match unpacking_in_progress.acquire(path.clone()) {
@@ -250,9 +251,11 @@ impl Download {
                 file.seek(SeekFrom::Start(idx.start))?;
                 let mut split_file = (&mut file).take(idx.end - idx.start);
 
-                let mut output = File::create(&path)?;
+                let mut output = File::create(&partial_path)?;
 
                 io::copy(&mut split_file, &mut output)?;
+
+                fs::rename(&partial_path, &path)?;
 
                 Ok(())
             })

--- a/moss/src/client/cache.rs
+++ b/moss/src/client/cache.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use snafu::{OptionExt, ResultExt as _, Snafu, ensure};
-use stone::{StoneDecodedPayload, StoneDigestWriter, StoneDigestWriterHasher, StonePayloadIndexRecord, StoneReadError};
+use stone::{StoneDecodedPayload, StoneDigestWriter, StoneDigestWriterHasher, StoneReadError};
 use tracing::warn;
 use url::Url;
 
@@ -234,9 +234,7 @@ impl Download {
             .flat_map(|p| &p.body)
             .collect::<Vec<_>>();
 
-        // If we don't have any files to unpack OR download was cached
-        // & all assets exist, we can skip unpacking
-        if indices.is_empty() || (self.was_cached && check_assets_exist(&indices, &self.installation)) {
+        if indices.is_empty() {
             return Ok(UnpackedAsset { payloads });
         }
 
@@ -334,14 +332,6 @@ impl Download {
 
         Ok(UnpackedAsset { payloads })
     }
-}
-
-/// Returns true if all assets already exist in the installation
-fn check_assets_exist(indices: &[&StonePayloadIndexRecord], installation: &Installation) -> bool {
-    indices.iter().all(|index| {
-        let path = asset_path(installation, &format!("{:02x}", index.digest));
-        path.exists()
-    })
 }
 
 /// Returns a fully qualified filesystem path to download the given hash ID into

--- a/moss/src/client/cache.rs
+++ b/moss/src/client/cache.rs
@@ -103,7 +103,7 @@ pub async fn fetch(
         });
     }
 
-    request::download_with_progress(url, &destination_path, |progress| {
+    let actual_hash = request::download_with_progress_and_sha256(url, &destination_path, |progress| {
         (on_progress)(Progress {
             delta: progress.delta,
             completed: progress.completed,
@@ -111,6 +111,15 @@ pub async fn fetch(
         });
     })
     .await?;
+
+    ensure!(
+        *hash == actual_hash,
+        BinaryStoneHashMismatchSnafu {
+            package: meta.name.to_string(),
+            expected: hash.clone(),
+            actual: actual_hash
+        }
+    );
 
     Ok(Download {
         id: meta.id().into(),
@@ -327,4 +336,10 @@ pub enum FetchError {
     Request { source: request::Error },
     #[snafu(context(false), display("io"))]
     Io { source: io::Error },
+    #[snafu(display("Binary stone hash mismatch for {package}: expected {expected}, got {actual}"))]
+    BinaryStoneHashMismatch {
+        package: String,
+        expected: String,
+        actual: String,
+    },
 }

--- a/moss/src/client/cache.rs
+++ b/moss/src/client/cache.rs
@@ -269,9 +269,33 @@ impl Download {
                     None => return Ok(()),
                 };
 
-                // This asset already exists
-                if path.exists() {
-                    return Ok(());
+                let is_unpacked_already = || -> Result<bool, UnpackError> {
+                    if fs::exists(&path)? {
+                        let mut hasher = StoneDigestWriterHasher::new();
+                        let mut file = File::open(&path)?;
+
+                        io::copy(&mut file, &mut StoneDigestWriter::new(io::sink(), &mut hasher))?;
+
+                        let actual_digest = hasher.digest128();
+
+                        return Ok(idx.digest == actual_digest);
+                    }
+
+                    Ok(false)
+                };
+
+                match is_unpacked_already() {
+                    Ok(true) => {
+                        return Ok(());
+                    }
+                    Ok(false) => {}
+                    // Always force unpack on any error checking cache validity
+                    Err(err) => {
+                        warn!(
+                            error = format!("{err:#}"),
+                            "Failed to verify if file is already unpacked, will re-unpack"
+                        );
+                    }
                 }
 
                 // Create parent dir

--- a/moss/src/client/prune.rs
+++ b/moss/src/client/prune.rs
@@ -356,7 +356,7 @@ fn remove_orphaned_files(
         let Some(file) = compute_path(hash.clone()) else {
             return Ok(acc);
         };
-        let partial = file.with_extension("part");
+        let partial = file.with_added_extension("part");
 
         // Remove if it exists
         if file.exists() {

--- a/moss/src/client/verify.rs
+++ b/moss/src/client/verify.rs
@@ -54,6 +54,7 @@ pub fn verify(client: &Client, yes: bool, verbose: bool) -> Result<(), client::E
     let mut issues = unique_assets
         .into_par_iter()
         .try_fold(Vec::new, |mut acc, (hash, meta)| -> io::Result<_> {
+            // Padded so output is consistent
             let display_hash = format!("{hash:0>32}");
 
             let path = cache::asset_path(&client.installation, &hash);
@@ -68,7 +69,7 @@ pub fn verify(client: &Client, yes: bool, verbose: bool) -> Result<(), client::E
                     pb.suspend(|| println!(" {} {display_hash} - {files:?}", "×".yellow()));
                 }
                 acc.push(Issue::MissingAsset {
-                    hash: display_hash,
+                    hash,
                     files,
                     packages: meta.into_iter().map(|(package, _)| package).collect(),
                 });
@@ -91,7 +92,7 @@ pub fn verify(client: &Client, yes: bool, verbose: bool) -> Result<(), client::E
                     pb.suspend(|| println!(" {} {display_hash} - {files:?}", "×".yellow()));
                 }
                 acc.push(Issue::CorruptAsset {
-                    hash: display_hash,
+                    hash,
                     files,
                     packages: meta.into_iter().map(|(package, _)| package).collect(),
                 });

--- a/moss/src/request.rs
+++ b/moss/src/request.rs
@@ -3,7 +3,7 @@
 
 use std::{
     io::{self},
-    path::{Path, PathBuf},
+    path::Path,
     pin::Pin,
     sync::OnceLock,
     task,
@@ -81,7 +81,7 @@ pub async fn download_with_progress_and_sha256(
 }
 
 async fn write_to_file<T: AsyncRead + Unpin>(reader: &mut T, to: &Path) -> Result<(), Error> {
-    let partial_path = PathBuf::from(format!("{}.part", to.display()));
+    let partial_path = to.with_added_extension("part");
 
     let mut out = File::create(&partial_path).await?;
 

--- a/moss/src/util.rs
+++ b/moss/src/util.rs
@@ -279,11 +279,20 @@ pub fn ignore_notfound(result: io::Result<()>) -> io::Result<()> {
 
 /// Computes the sha256 hash of the provided reader
 pub fn sha256_hash<R: Read>(reader: &mut R) -> io::Result<String> {
-    let mut writer = Sha256Wrapper::new(io::sink());
+    let mut reader = Sha256Wrapper::new(reader);
 
-    io::copy(reader, &mut writer)?;
+    io::copy(&mut reader, &mut io::sink())?;
 
-    Ok(writer.finalize())
+    Ok(reader.finalize())
+}
+
+/// Computes the sha256 hash of the provided reader
+pub async fn sha256_hash_async<R: AsyncRead + Unpin>(reader: &mut R) -> io::Result<String> {
+    let mut reader = Sha256Wrapper::new(reader);
+
+    tokio::io::copy(&mut reader, &mut tokio::io::sink()).await?;
+
+    Ok(reader.finalize())
 }
 
 /// Wraps an inner reader or writer and provides


### PR DESCRIPTION
A smattering of (long overdue?) reliability and integrity improvements surrounding downloads and copies to the CAS, including:

- Fix state verify hash padding mismatch
- Unpack CAS files to .part w/ atomic rename
- Fix state prune partial path resolution
- Verify downloaded binary stone SHA256 against recorded upstream stone.index hash
- Verify hash when checking existing cached assets
- Verify CAS file hashes during unpack of downloaded .stones
- Verify CAS file hashes before skipping unpack when assets already exists in cache