### PR TITLE
fix: boulder recipe update builds a bogus upstream URL when release monitoring returns an empty version

### DIFF
--- a/boulder/src/cli/recipe.rs
+++ b/boulder/src/cli/recipe.rs
@@ -173,6 +173,10 @@ fn detect_update(recipe_path: &Path, parsed_recipe: &recipe::Parsed, verbose: bo
         .cloned()
         .unwrap_or_else(|| response.latest_version.unwrap_or_default());
 
+    if newest.is_empty() {
+        return Err(Error::AutoupdateNoVersionFound);
+    }
+
     println!("Newest version found: {newest}, current version: {current_version}");
 
     if newest == *current_version {
@@ -209,6 +213,10 @@ enum DetectedUpdate {
 }
 
 fn guess_new_url(new_version: &str, current_url: &str, verbose: bool) -> Result<String, Error> {
+    if new_version.is_empty() {
+        return Err(Error::AutoupdateNoVersionFound);
+    }
+
     let upstreams_parser = VersionExtractor::new();
     let parsed_upstream = upstreams_parser.extract(current_url)?;
 
@@ -604,6 +612,10 @@ pub enum Error {
         "Missing monitoring file, cannot autoupdate. Either add a monitoring file or supply an explicit --ver or --upstream."
     )]
     AutoupdateMissingMonitoringFile,
+    #[error(
+        "Release monitoring returned no version for the configured project id, cannot autoupdate. Check monitoring.yaml or supply an explicit --ver or --upstream."
+    )]
+    AutoupdateNoVersionFound,
     #[error("Mismatch for upstream[{0}], expected {1} got {2}")]
     UpstreamMismatch(usize, &'static str, &'static str),
     #[error("load macros")]
@@ -693,5 +705,17 @@ mod tests {
             new_url,
             "https://github.com/systemd/systemd/archive/refs/tags/v260.1.tar.gz"
         );
+    }
+
+    #[test]
+    fn test_guess_new_url_rejects_empty_version() {
+        let err = guess_new_url(
+            "",
+            "https://github.com/numpy/numpy/releases/download/v2.4.6/numpy-2.4.6.tar.gz",
+            false,
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, Error::AutoupdateNoVersionFound));
     }
 }


### PR DESCRIPTION
## Summary
In `detect_update()` in `boulder/src/cli/recipe.rs`, `newest` is built as `response.stable_versions.first().cloned().unwrap_or_else(|| response.latest_version.unwrap_or_default())`, so a monitoring response with no stable versions and no latest version silently yields `""`; the only guard is the equality check `newest == *current_version`, which an empty string passes. Add an explicit guard right after computing `newest`: if it is empty, return a new `Error::AutoupdateNoVersionFound` variant (added to the `Error` enum in the same file) whose message tells the user that release monitoring returned no version for the configured project id and to check monitoring.yaml or supply an explicit `--ver`/`--upstream`, mirroring the existing `AutoupdateMissingMonitoringFile` message style. As a defensive second layer, make `guess_new_url()` reject an empty `new_version` with the same error so no caller path can splice an empty version into a URL.

## Why this matters
Running `boulder up` (the `recipe update` autoupdate path) on python-numpy printed `Newest version found: , current version: 2.4.6` and then failed with `fetch: HTTP status client error (404 Not Found) for url (https://github.com/numpy/numpy/releases/download/v/numpy-.tar.gz)`. The release-monitoring lookup produced no version for the project (the reporter traced their case to the recipe's monitoring feed pointing at GitHub's releases.atom), but boulder proceeded anyway with an empty version string, spliced it into the old upstream URL, and produced a confusing 404 instead of a clear diagnostic. The reporter worked around it by repointing their recipe's monitoring.yaml at pypi.org, but the boulder-side defect - fabricating and fetching a URL from an empty version - remains open and unassigned, with no prior PRs.

See https://github.com/AerynOS/os-tools/issues/799.

## Testing
- Happy path: existing `test_guess_new_url` cases (NetworkManager, nano, ghex, upower, systemd URLs) still pass unchanged. - Empty version: `guess_new_url("", "https://github.com/numpy/numpy/releases/download/v2.4.6/numpy-2.4.6.tar.gz", false)` returns the new error instead of `.../download/v/numpy-.tar.gz`. - Error path: `detect_update` with a monitoring response containing no stable_versions and no latest_version returns `Error::AutoupdateNoVersionFound` (exercised via the empty-`newest` guard) rather than proceeding to URL construction and a network fetch. - Up-to-date path unaffected: when `newest` equals the current version, the command still prints "Already up-to-date!" and exits cleanly.

Fixes #799
