### PR TITLE
boulder: fix typo where "gcc" was used as the toolchain name

### DIFF
--- a/boulder/data/macros/arch/aarch64.yaml
+++ b/boulder/data/macros/arch/aarch64.yaml
@@ -22,6 +22,6 @@ flags:
         llvm:
             c         : "-march=armv8-a+simd+fp+crypto -mtune=cortex-a72"
             cxx       : "-march=armv8-a+simd+fp+crypto -mtune=cortex-a72"
-        gcc:
+        gnu:
             c         : "-march=armv8-a+simd+fp+crypto -mtune=cortex-a72.cortex-a53"
             cxx       : "-march=armv8-a+simd+fp+crypto -mtune=cortex-a72.cortex-a53"

--- a/boulder/data/macros/arch/riscv64.yaml
+++ b/boulder/data/macros/arch/riscv64.yaml
@@ -22,6 +22,6 @@ flags:
         llvm:
             c         : "-march=rv64gc -mtune=generic-ooo"
             cxx       : "-march=rv64gc -mtune=generic-ooo"
-        gcc:
+        gnu:
             c         : "-march=rv64gc -mtune=generic-ooo"
             cxx       : "-march=rv64gc -mtune=generic-ooo"


### PR DESCRIPTION
While looking around to see how I could refactor the tuning flags, I found out that `gcc` is used as a toolchain name instead of `gnu` in two places.

This PR fixes that.