### PR TITLE
Github Actions: Update ci.yaml and release.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Check for typos
-        uses: crate-ci/typos@v1.43.5
+        uses: crate-ci/typos@v1.48.0
 
       - name: Check REUSE compliance
         uses: fsfe/reuse-action@v6.0.0
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install LLVM and Clang
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Install musl
       run: sudo apt-get install musl-tools


### PR DESCRIPTION
## Summary

Update of github-actions to their latest respective versions

- Update actions/checkout v6 to v7
- Update crate-ci/typos v1.43.5 to v1.48.0

## Testing

Will be testing when github-actions runs on this PR