### PR TITLE
moss: Upgrade native fstx driver

### DIFF
--- a/moss/src/client/mod.rs
+++ b/moss/src/client/mod.rs
@@ -11,7 +11,10 @@
 use std::{
     borrow::Borrow,
     fmt, io,
-    os::{fd::RawFd, unix::fs::symlink},
+    os::{
+        fd::{AsRawFd, FromRawFd, RawFd},
+        unix::fs::symlink,
+    },
     path::{Path, PathBuf},
     time::{Duration, Instant},
 };
@@ -21,17 +24,18 @@ use fs_err as fs;
 use futures_util::{StreamExt, TryStreamExt, stream};
 use itertools::Itertools;
 use nix::{
+    NixPath,
     errno::Errno,
-    fcntl::{self, OFlag},
-    libc::{AT_FDCWD, RENAME_EXCHANGE, SYS_renameat2, syscall},
-    sys::stat::{Mode, fchmodat, mkdirat},
-    unistd::{close, linkat, mkdir, symlinkat},
+    fcntl::{self, AtFlags, OFlag},
+    libc::{AT_FDCWD, FICLONE, RENAME_EXCHANGE, SYS_renameat2, ioctl, syscall},
+    sys::stat::{Mode, fchmod, fstat, mkdirat, umask},
+    unistd::{Gid, Uid, close, fchown, mkdir, symlinkat},
 };
 use postblit::TriggerScope;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use stone::{StoneDecodedPayload, StonePayloadLayoutFile, StonePayloadLayoutRecord};
 use thiserror::Error;
-use tracing::{info, info_span, trace};
+use tracing::{info, info_span, trace, warn};
 use tui::{MultiProgress, ProgressBar, ProgressStyle, Styled};
 use vfs::tree::{BlitFile, Element, builder::TreeBuilder};
 
@@ -216,7 +220,7 @@ impl Client {
     pub fn ephemeral(self, blit_root: impl Into<PathBuf>) -> Result<Self, Error> {
         let blit_root = blit_root.into();
 
-        if blit_root.canonicalize()? == self.installation.root.canonicalize()? {
+        if blit_root.exists() && blit_root.canonicalize()? == self.installation.root.canonicalize()? {
             return Err(Error::EphemeralInstallationRoot);
         }
 
@@ -597,28 +601,9 @@ impl Client {
         }
 
         // Now swap staging with live
-        Self::atomic_swap(&usr_source, &usr_target)?;
+        atomic_swap(&usr_source, &usr_target)?;
 
         Ok(())
-    }
-
-    /// syscall based wrapper for renameat2 so we can support musl libc which
-    /// unfortunately does not expose the API.
-    /// largely modelled on existing renameat2 API in nix crae
-    fn atomic_swap<A: ?Sized + nix::NixPath, B: ?Sized + nix::NixPath>(old_path: &A, new_path: &B) -> nix::Result<()> {
-        let result = old_path.with_nix_path(|old| {
-            new_path.with_nix_path(|new| unsafe {
-                syscall(
-                    SYS_renameat2,
-                    AT_FDCWD,
-                    old.as_ptr(),
-                    AT_FDCWD,
-                    new.as_ptr(),
-                    RENAME_EXCHANGE,
-                )
-            })
-        })?? as i32;
-        Errno::result(result).map(drop)
     }
 
     /// Archive old states (currently not "activated") into their respective tree
@@ -1000,6 +985,142 @@ pub fn vfs(layouts: Vec<(package::Id, StonePayloadLayoutRecord)>) -> Result<vfs:
     Ok(tbuild.tree()?)
 }
 
+#[derive(Debug, Clone, Copy, strum::Display)]
+#[strum(serialize_all = "lowercase")]
+enum BlitStrategy {
+    Reflink,
+    Hardlink,
+    Copy,
+}
+
+/// Attempts to find the best blit strategy in order of priority: `reflink` -> `hardlink` -> `copy`
+///
+/// `copy` is only used if `EXDEV` / `cross-device link not permitted`, otherwise
+/// any other error during this test falls back to `hardlink` to ensure we don't
+/// accidentally `copy` on unexpected errors, and to introduce regression against
+/// the previous `hardlink` only behavior
+fn identify_blit_strategy(installation: &Installation, blit_target: &Path) -> BlitStrategy {
+    let from = installation.cache_path(".link-test");
+    let to = blit_target.join(".link-test");
+
+    let identify = || -> io::Result<_> {
+        // Remove both if they already exist
+        if from.exists() {
+            fs::remove_file(&from)?;
+        }
+        if to.exists() {
+            fs::remove_file(&to)?;
+        }
+
+        // Create empty from
+        fs::write(&from, b"")?;
+
+        // Open from file
+        let source = fs::OpenOptions::new().read(true).open(&from)?;
+        // Target file should be _new_ for reflink test
+        let target = fs::OpenOptions::new().write(true).create_new(true).open(&to)?;
+
+        // Attempt reflink
+        let res = reflink(source, target);
+
+        if res.is_ok() {
+            return Ok(BlitStrategy::Reflink);
+        }
+
+        // Remove to created above so we can test hardlink
+        fs::remove_file(&to)?;
+
+        // Attempt hardlink
+        let res = linkat(None, &from, None, &to);
+
+        match res {
+            Err(Errno::EXDEV) => Ok(BlitStrategy::Copy),
+            _ => Ok(BlitStrategy::Hardlink),
+        }
+    };
+
+    // Fallback to hardlink on error
+    let strategy = identify().unwrap_or_else(|err| {
+        warn!(
+            error = format!("{err:#}"),
+            "Failed to identify blit strategy, falling back to hardlink strategy"
+        );
+        BlitStrategy::Hardlink
+    });
+
+    // Cleanup
+    let _ = fs::remove_file(&from);
+    let _ = fs::remove_file(&to);
+
+    strategy
+}
+
+/// syscall based wrapper for renameat2 so we can support musl libc which
+/// unfortunately does not expose the API.
+/// largely modelled on existing renameat2 API in nix crate
+fn atomic_swap<A: ?Sized + NixPath, B: ?Sized + NixPath>(old_path: &A, new_path: &B) -> nix::Result<()> {
+    let result = old_path.with_nix_path(|old| {
+        new_path.with_nix_path(|new| unsafe {
+            syscall(
+                SYS_renameat2,
+                AT_FDCWD,
+                old.as_ptr(),
+                AT_FDCWD,
+                new.as_ptr(),
+                RENAME_EXCHANGE,
+            )
+        })
+    })?? as i32;
+    Errno::result(result).map(drop)
+}
+
+/// [`nix::unistd::linkat`] doesn't supply AT_EMPTY_PATH
+/// to allow `olddirfd` to be the source FD, so we override
+/// their implementation to support this usecase
+fn linkat<P: ?Sized + NixPath>(
+    olddirfd: Option<RawFd>,
+    oldpath: &P,
+    newdirfd: Option<RawFd>,
+    newpath: &P,
+) -> nix::Result<()> {
+    use nix::libc;
+
+    let atflag = if olddirfd.is_some() && oldpath.is_empty() {
+        AtFlags::AT_EMPTY_PATH
+    } else {
+        AtFlags::empty()
+    };
+    let at_rawfd = |fd: Option<RawFd>| match fd {
+        Some(fd) => fd,
+        None => AT_FDCWD,
+    };
+
+    let res = oldpath.with_nix_path(|oldcstr| {
+        newpath.with_nix_path(|newcstr| unsafe {
+            libc::linkat(
+                at_rawfd(olddirfd),
+                oldcstr.as_ptr(),
+                at_rawfd(newdirfd),
+                newcstr.as_ptr(),
+                atflag.bits(),
+            )
+        })
+    })??;
+    Errno::result(res).map(drop)
+}
+
+fn reflink(source: impl AsRawFd, target: impl AsRawFd) -> nix::Result<()> {
+    let res = unsafe { ioctl(target.as_raw_fd(), FICLONE, source.as_raw_fd()) };
+    Errno::result(res).map(drop)
+}
+
+struct BlitContext<'a> {
+    is_user_root: bool,
+    blit_strategy: BlitStrategy,
+    cache_fd: RawFd,
+    progress: &'a ProgressBar,
+}
+
 /// Blit the packages to a filesystem root
 ///
 /// This functionality is core to all moss filesystem transactions, forming the entire
@@ -1013,8 +1134,18 @@ pub fn vfs(layouts: Vec<(package::Id, StonePayloadLayoutRecord)>) -> Result<vfs:
 /// This provides a very quick means to generate a hardlinked "snapshot" on-demand,
 /// which can then be activated via [`Self::promote_staging`]
 pub fn blit_root(installation: &Installation, tree: &vfs::Tree<PendingFile>, blit_target: &Path) -> Result<(), Error> {
-    // undirt.
-    fs::remove_dir_all(blit_target)?;
+    let is_user_root = Uid::effective().is_root();
+
+    // Recreate dir
+    let _ = fs::remove_dir_all(blit_target);
+    mkdir(blit_target, Mode::from_bits_truncate(0o755))?;
+
+    // Ensure umask is cleared so we get exact modes
+    let old_umask = umask(Mode::empty());
+
+    // Identify blit strategy based on FS in use
+    let blit_strategy = identify_blit_strategy(installation, blit_target);
+    info!(%blit_strategy, "Blit strategy identified");
 
     let progress = ProgressBar::new(1).with_style(
         ProgressStyle::with_template("\n|{bar:20.red/blue}| {pos}/{len} {msg}")
@@ -1034,6 +1165,13 @@ pub fn blit_root(installation: &Installation, tree: &vfs::Tree<PendingFile>, bli
     let cache_dir = installation.assets_path("v2");
     let cache_fd = fcntl::open(&cache_dir, OFlag::O_DIRECTORY | OFlag::O_RDONLY, Mode::empty())?;
 
+    let ctx = BlitContext {
+        is_user_root,
+        blit_strategy,
+        cache_fd,
+        progress: &progress,
+    };
+
     // We need to ensure this runtime is dropped so it doesn't linger
     // since this is in the boulder call path & boulder can't have
     // multithreading when CLONE into a user namespace / "container"
@@ -1041,7 +1179,6 @@ pub fn blit_root(installation: &Installation, tree: &vfs::Tree<PendingFile>, bli
 
     rayon_runtime.install(|| -> Result<(), Error> {
         if let Some(root) = tree.structured() {
-            mkdir(blit_target, Mode::from_bits_truncate(0o755))?;
             let root_dir = fcntl::open(blit_target, OFlag::O_DIRECTORY | OFlag::O_RDONLY, Mode::empty())?;
 
             if let Element::Directory(_, _, children) = root {
@@ -1051,7 +1188,7 @@ pub fn blit_root(installation: &Installation, tree: &vfs::Tree<PendingFile>, bli
                         .into_par_iter()
                         .map(|child| {
                             let _guard = current_span.enter();
-                            blit_element(root_dir, cache_fd, child, &progress)
+                            blit_element(&ctx, root_dir, child)
                         })
                         .try_reduce(BlitStats::default, |a, b| Ok(a.merge(b)))?,
                 );
@@ -1063,6 +1200,9 @@ pub fn blit_root(installation: &Installation, tree: &vfs::Tree<PendingFile>, bli
         Ok(())
     })?;
 
+    // Cleanup
+    close(ctx.cache_fd)?;
+    umask(old_umask);
     progress.finish_and_clear();
 
     let elapsed = now.elapsed();
@@ -1081,15 +1221,10 @@ pub fn blit_root(installation: &Installation, tree: &vfs::Tree<PendingFile>, bli
 /// Recursively write a directory, or a single flat inode, to the staging tree.
 /// Care is taken to retain the directory file descriptor to avoid costly path
 /// resolution at runtime.
-fn blit_element(
-    parent: RawFd,
-    cache: RawFd,
-    element: Element<'_, PendingFile>,
-    progress: &ProgressBar,
-) -> Result<BlitStats, Error> {
+fn blit_element(ctx: &BlitContext<'_>, parent: RawFd, element: Element<'_, PendingFile>) -> Result<BlitStats, Error> {
     let mut stats = BlitStats::default();
 
-    progress.inc(1);
+    ctx.progress.inc(1);
 
     let (_, item) = match &element {
         Element::Directory(_, item, _) => ("directory", item),
@@ -1097,9 +1232,9 @@ fn blit_element(
     };
 
     trace!(
-        progress = progress.position() as f32 / progress.length().unwrap_or(1) as f32,
-        current = progress.position() as usize,
-        total = progress.length().unwrap_or(0) as usize,
+        progress = ctx.progress.position() as f32 / ctx.progress.length().unwrap_or(1) as f32,
+        current = ctx.progress.position() as usize,
+        total = ctx.progress.length().unwrap_or(0) as usize,
         event_type = "progress_update",
         "Blitting {}",
         item.path()
@@ -1108,7 +1243,7 @@ fn blit_element(
     match element {
         Element::Directory(name, item, children) => {
             // Construct within the parent
-            blit_element_item(parent, cache, name, item, &mut stats)?;
+            blit_element_item(ctx, parent, name, item, &mut stats)?;
 
             // open the new dir
             let newdir = fcntl::openat(parent, name, OFlag::O_RDONLY | OFlag::O_DIRECTORY, Mode::empty())?;
@@ -1119,7 +1254,7 @@ fn blit_element(
                     .into_par_iter()
                     .map(|child| {
                         let _guard = current_span.enter();
-                        blit_element(newdir, cache, child, progress)
+                        blit_element(ctx, newdir, child)
                     })
                     .try_reduce(BlitStats::default, |a, b| Ok(a.merge(b)))?,
             );
@@ -1129,7 +1264,7 @@ fn blit_element(
             Ok(stats)
         }
         Element::Child(name, item) => {
-            blit_element_item(parent, cache, name, item, &mut stats)?;
+            blit_element_item(ctx, parent, name, item, &mut stats)?;
 
             Ok(stats)
         }
@@ -1145,12 +1280,14 @@ fn blit_element(
 /// * `subpath` - the base name of the new inode
 /// * `item`    - New inode being recorded
 fn blit_element_item(
+    ctx: &BlitContext<'_>,
     parent: RawFd,
-    cache: RawFd,
     subpath: &str,
     item: &PendingFile,
     stats: &mut BlitStats,
 ) -> Result<(), Error> {
+    const EMPTY_FILE_HASH: u128 = 0x99aa_06d3_0147_98d8_6001_c324_468d_497f;
+
     match &item.layout.file {
         StonePayloadLayoutFile::Regular(id, _) => {
             let hash = format!("{id:02x}");
@@ -1163,35 +1300,134 @@ fn blit_element_item(
             // Link relative from cache to target
             let fp = directory.join(hash);
 
+            // Strip write bit.
+            //
+            // Our blitted roots are intended for read-only, immutable use.
+            // This doesn't necessarily help enforce anything and we will
+            // leverage other strategies to enforce true immutability. But
+            // no write bit is ever needed, so may as well strip it.
+            let blit_mode = item.layout.mode & !0o222;
+
             match *id {
                 // Mystery empty-file hash. Do not allow dupes!
                 // https://github.com/AerynOS/os-tools/issues/372
-                0x99aa_06d3_0147_98d8_6001_c324_468d_497f => {
+                EMPTY_FILE_HASH => {
                     let fd = fcntl::openat(
                         parent,
                         subpath,
                         OFlag::O_CREAT | OFlag::O_WRONLY | OFlag::O_TRUNC,
-                        Mode::from_bits_truncate(item.layout.mode),
+                        // We can specify mode here used to create the file.
+                        Mode::from_bits_truncate(blit_mode),
                     )?;
                     close(fd)?;
                 }
                 // Regular file
                 _ => {
-                    linkat(
-                        Some(cache),
-                        fp.to_str().unwrap(),
-                        Some(parent),
-                        subpath,
-                        nix::unistd::LinkatFlags::NoSymlinkFollow,
-                    )?;
+                    match ctx.blit_strategy {
+                        BlitStrategy::Reflink => {
+                            // Open FD to source
+                            let src = fcntl::openat(ctx.cache_fd, &fp, OFlag::O_RDONLY, Mode::empty())?;
+                            // Create new inode & get its FD.
+                            let dest = fcntl::openat(
+                                parent,
+                                subpath,
+                                OFlag::O_CREAT | OFlag::O_EXCL | OFlag::O_WRONLY,
+                                // We can specify mode here used to create the file.
+                                Mode::from_bits_truncate(blit_mode),
+                            )?;
 
-                    // Fix permissions
-                    fchmodat(
-                        Some(parent),
-                        subpath,
-                        Mode::from_bits_truncate(item.layout.mode),
-                        nix::sys::stat::FchmodatFlags::NoFollowSymlink,
-                    )?;
+                            // Apply special bits stripped from mode during `openat`
+                            if blit_mode & 0o7000 > 0 {
+                                fchmod(dest, Mode::from_bits_truncate(blit_mode))?;
+                            }
+
+                            // Reflink from source to dest
+                            reflink(src, dest)?;
+
+                            // Update ownership if we can
+                            if ctx.is_user_root {
+                                let uid = Uid::from_raw(item.layout.uid);
+                                let gid = Gid::from_raw(item.layout.gid);
+
+                                if !(uid.is_root() || gid.as_raw() == 0) {
+                                    fchown(
+                                        dest,
+                                        Some(Uid::from_raw(item.layout.uid)),
+                                        Some(Gid::from_raw(item.layout.gid)),
+                                    )?;
+                                }
+                            }
+
+                            // Cleanup FDs
+                            close(src)?;
+                            close(dest)?;
+                        }
+                        BlitStrategy::Hardlink => {
+                            // Open FD for CAS file
+                            let src = fcntl::openat(ctx.cache_fd, &fp, OFlag::O_RDONLY, Mode::empty())?;
+                            // Get existing mode
+                            let existing_mode = fstat(src)?.st_mode;
+
+                            // Handle permissions
+                            //
+                            // Since hardlinks share inode / metadata, this is a
+                            // dangerous operation as any changes here impact ALL
+                            // links to this file and may impact the running system.
+                            // We need to ensure mode can never lose its executability
+                            // if another file needs that executability.
+                            //
+                            // We therefore combine the two (more permissive) and always
+                            // strip out the `w` bit since this should be immutable / read-only.
+                            // If that is different from the existing mode, we can safely apply it.
+                            let desired_mode = (existing_mode | blit_mode) & !0o222;
+
+                            if existing_mode != desired_mode {
+                                fchmod(src, Mode::from_bits_truncate(desired_mode))?;
+                            }
+
+                            // Create link to blit target
+                            linkat(Some(src), "", Some(parent), subpath)?;
+                        }
+                        #[allow(clippy::disallowed_types)]
+                        BlitStrategy::Copy => {
+                            // Open FD to source
+                            let src = fcntl::openat(ctx.cache_fd, &fp, OFlag::O_RDONLY, Mode::empty())?;
+                            // Create dest inode & get its FD.
+                            let dest = fcntl::openat(
+                                parent,
+                                subpath,
+                                OFlag::O_CREAT | OFlag::O_EXCL | OFlag::O_WRONLY,
+                                // We can specify mode here used to create the file.
+                                Mode::from_bits_truncate(blit_mode),
+                            )?;
+
+                            // Apply special bits stripped from mode during `openat`
+                            if blit_mode & 0o7000 > 0 {
+                                fchmod(dest, Mode::from_bits_truncate(blit_mode))?;
+                            }
+
+                            // Copy (rust uses copy_file_range where possible)
+                            //
+                            // FDs are dropped when File is dropped
+                            let mut from = unsafe { std::fs::File::from_raw_fd(src) };
+                            let mut to = unsafe { std::fs::File::from_raw_fd(dest) };
+                            io::copy(&mut from, &mut to).map_err(|_| Errno::last())?;
+
+                            // Update ownership if we can
+                            if ctx.is_user_root {
+                                let uid = Uid::from_raw(item.layout.uid);
+                                let gid = Gid::from_raw(item.layout.gid);
+
+                                if !(uid.is_root() || gid.as_raw() == 0) {
+                                    fchown(
+                                        dest,
+                                        Some(Uid::from_raw(item.layout.uid)),
+                                        Some(Gid::from_raw(item.layout.gid)),
+                                    )?;
+                                }
+                            }
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
This commit applies a few major upgrades & fixes to our "native" fstx driver. I use "native" here instead of "hardlink" as we've previously described it since we now support "reflinks" where possible and also a fallback "copy" strategy when EXDEV / cross link.

The following notable changes are made:

- `reflinks` are now used when supported. This is an actual _correct_ implementation since we can apply `mode/uid/gid` bits on a per-metadata basis independently of the underlying shared CAS (content address store) blocks. This means `uid/gid` is applied for this strategy when blitting as root.
- `copy` is added as a fallback blit strategy only when EXDEV / cross link device error occurs (writing between separate filesystems). Previously this was an error since we could only `hardlink` and uses such as `moss it --to` would fail if writing out to some other filesystem. Like the `reflink` stategy, we can safely set `mode/uid/gid` bits here.
- The now `hardlink` strategy fixes a long standing safety issue (though no known package intersection is known to trigger this), where the `fchownat` call applying the incoming layout `mode` to the file can cause a file that already has its executability `x` bit set to lose its `x` bit. Since hardlinks all share an inode & the same metadata, we're really talking about `fchown` of the underlying CAS file, which is linked across ALL relevant states & possibly the running system root. A loss of `x` on a critical system binary linked into the root state can cause system unstability or crash. We now use a defensive strategy which ensures the `x` bit is always preserved (`old_mode | new_mode`) and only make the `mode` change when necessary.
- We now strip `w` bit on all modes applied from each blit strategy (`mode & 0o555`) since our `/usr` is intended to be read-only. We plan to further enforce this in the future via other means for true immutability.
- `umask` is always cleared prior to blitting so that `mode` bits are applied as-is for `openat` operations on the `reflink` and `copy` strategies, where `mode` can be defined atomically in `openat` when creating the destination file.
- Fixes a bug where `--to` had to exist ahead of time, even though we forcefully recreate the directory anyway.