### PR TITLE
Accept Git repository URLs in `boulder recipe new`

### DIFF
--- a/boulder/src/cli/recipe.rs
+++ b/boulder/src/cli/recipe.rs
@@ -17,7 +17,7 @@ use fs_err::{self as fs};
 use itertools::Itertools;
 use moss::{request, runtime, util};
 use similar::TextDiff;
-use stone_recipe::upstream;
+use stone_recipe::upstream::{self, SourceUri};
 use tempfile::NamedTempFile;
 use thiserror::Error;
 use tui::{
@@ -64,7 +64,7 @@ pub enum Subcommand {
         #[arg(short, long, default_value = ".", help = "Location to output generated files")]
         output: PathBuf,
         #[arg(required = true, value_name = "URI", help = "Source archive URIs")]
-        upstreams: Vec<Url>,
+        upstreams: Vec<SourceUri>,
     },
     #[command(about = LONG_UPDATE_ABOUT)]
     Update {
@@ -281,7 +281,7 @@ fn bump(recipe: PathBuf, release: Option<u64>) -> Result<(), Error> {
     Ok(())
 }
 
-fn new(env: Env, output: PathBuf, upstreams: Vec<Url>) -> Result<(), Error> {
+fn new(env: Env, output: PathBuf, upstreams: Vec<SourceUri>) -> Result<(), Error> {
     const RECIPE_FILE: &str = "stone.yaml";
     const MONITORING_FILE: &str = "monitoring.yaml";
 

--- a/boulder/src/draft.rs
+++ b/boulder/src/draft.rs
@@ -8,9 +8,9 @@ use chrono::{Datelike, Utc};
 use itertools::Itertools;
 use licenses::match_licences;
 use moss::{Dependency, util};
+use stone_recipe::upstream::SourceUri;
 use thiserror::Error;
 use tui::Styled;
-use url::Url;
 
 use crate::Env;
 
@@ -26,7 +26,7 @@ pub mod upstream;
 
 pub struct Drafter {
     env: Env,
-    upstreams: Vec<Url>,
+    upstreams: Vec<SourceUri>,
 }
 
 pub struct Draft {
@@ -35,7 +35,7 @@ pub struct Draft {
 }
 
 impl Drafter {
-    pub fn new(env: Env, upstreams: Vec<Url>) -> Self {
+    pub fn new(env: Env, upstreams: Vec<SourceUri>) -> Self {
         Self { env, upstreams }
     }
 

--- a/boulder/src/draft/metadata.rs
+++ b/boulder/src/draft/metadata.rs
@@ -56,7 +56,7 @@ impl Metadata {
                 let uri_to_use = if i == 0 && !self.source.uri.is_empty() {
                     &self.source.uri
                 } else {
-                    uri.as_str()
+                    &uri.to_string()
                 };
                 format!("    - {uri_to_use} : {hash}")
             })

--- a/boulder/src/draft/metadata/basic.rs
+++ b/boulder/src/draft/metadata/basic.rs
@@ -3,12 +3,16 @@
 
 use moss::util;
 use regex::Regex;
-use url::Url;
+use stone_recipe::upstream::SourceUri;
 
 use super::Source;
 
-pub fn source(upstream: &Url) -> Option<Source> {
-    let filename = util::uri_file_name(upstream);
+pub fn source(upstream: &SourceUri) -> Option<Source> {
+    if !matches!(upstream.kind, stone_recipe::upstream::Kind::Archive) {
+        return None;
+    }
+
+    let filename = util::uri_file_name(&upstream.url);
 
     let regex = Regex::new(r"^([a-zA-Z0-9_-]+)-([a-zA-Z0-9._-]+)\.(zip|tar|sh|bin\.*)").unwrap();
     let captures = regex.captures(filename)?;
@@ -16,7 +20,7 @@ pub fn source(upstream: &Url) -> Option<Source> {
     let name = captures.get(1)?.as_str().to_owned();
     let version = captures.get(2)?.as_str().to_owned();
 
-    let (homepage, _) = upstream.as_str().rsplit_once('/')?;
+    let (homepage, _) = upstream.url.as_str().rsplit_once('/')?;
 
     Some(Source {
         name,

--- a/boulder/src/draft/metadata/github.rs
+++ b/boulder/src/draft/metadata/github.rs
@@ -2,28 +2,37 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use regex::Regex;
-use url::Url;
+use stone_recipe::upstream::{self, SourceUri};
 
 use super::Source;
 
-pub fn source(upstream: &Url) -> Option<Source> {
-    let automatic_regex = Regex::new(
-        r"\w+\:\/\/github\.com\/([A-Za-z0-9-_]+)\/([A-Za-z0-9-_]+)\/archive\/refs\/tags\/([A-Za-z0-9.-_]+)\.(tar|zip)",
-    )
-    .unwrap();
-    let manual_regex = Regex::new(
-        r"\w+\:\/\/github\.com\/([A-Za-z0-9-_]+)\/([A-Za-z0-9-_]+)\/releases\/download\/([A-Za-z0-9-_.]+)\/.*",
-    )
-    .unwrap();
+pub fn source(upstream: &SourceUri) -> Option<Source> {
+    // We accept no usernames and ports,
+    // just plain access to github.com.
+    if upstream.url.authority() != "github.com" {
+        return None;
+    }
+    // We do not support query parameters or fragments in the URL.
+    if upstream.url.query().is_some() || upstream.url.fragment().is_some() {
+        return None;
+    }
 
-    for matcher in [automatic_regex, manual_regex] {
-        let Some(captures) = matcher.captures(upstream.as_str()) else {
+    let path_matchers: &[Regex] = match upstream.kind {
+        upstream::Kind::Archive => &[
+            Regex::new(r"([\w-]+)\/([\w-]+)\/archive\/refs\/tags\/([\w.-]+)\.(?:tar|zip)").unwrap(),
+            Regex::new(r"([\w-]+)\/([\w-]+)\/releases\/download\/([\w.-]+)\/.*").unwrap(),
+        ],
+        upstream::Kind::Git => &[Regex::new(r"([\w-]+)\/([\w-]+)(?:\.git)?").unwrap()],
+    };
+
+    for matcher in path_matchers {
+        let Some(captures) = matcher.captures(&upstream.url.path()) else {
             continue;
         };
 
         let owner = captures.get(1)?.as_str();
         let project = captures.get(2)?.as_str();
-        let version = captures.get(3)?.as_str().to_owned();
+        let version = captures.get(3).map_or("UNDETECTED", |v| v.as_str()).to_owned();
 
         // Strip 'v' if the second character is a digit e.g. v1.2.3
         let version =
@@ -52,9 +61,12 @@ mod tests {
     #[test]
     fn test_automatic_regex() {
         let url_str = "https://github.com/GNOME/pango/archive/refs/tags/1.57.0.tar.gz";
-        let url = Url::parse(url_str).unwrap();
+        let uri = SourceUri {
+            kind: upstream::Kind::Archive,
+            url: Url::parse(url_str).unwrap(),
+        };
 
-        let source = source(&url);
+        let source = source(&uri);
         assert!(source.is_some());
 
         let source = source.unwrap();
@@ -67,9 +79,12 @@ mod tests {
     #[test]
     fn test_manual_regex() {
         let url_str = "https://github.com/streamlink/streamlink/releases/download/8.2.0/streamlink-8.2.0.tar.gz";
-        let url = Url::parse(url_str).unwrap();
+        let uri = SourceUri {
+            kind: upstream::Kind::Archive,
+            url: Url::parse(url_str).unwrap(),
+        };
 
-        let source = source(&url);
+        let source = source(&uri);
         assert!(source.is_some());
 
         let source = source.unwrap();
@@ -82,9 +97,12 @@ mod tests {
     #[test]
     fn test_automatic_regex_with_v_prefix() {
         let url_str = "https://github.com/chatty/chatty/archive/refs/tags/v0.28.tar.gz";
-        let url = Url::parse(url_str).unwrap();
+        let uri = SourceUri {
+            kind: upstream::Kind::Archive,
+            url: Url::parse(url_str).unwrap(),
+        };
 
-        let source = source(&url);
+        let source = source(&uri);
         assert!(source.is_some());
 
         let source = source.unwrap();
@@ -97,9 +115,12 @@ mod tests {
     #[test]
     fn test_manual_regex_string_version() {
         let url_str = "https://github.com/unicode-org/icu/releases/download/release-76-1/icu4c-76_1-src.tgz";
-        let url = Url::parse(url_str).unwrap();
+        let uri = SourceUri {
+            kind: upstream::Kind::Archive,
+            url: Url::parse(url_str).unwrap(),
+        };
 
-        let source = source(&url);
+        let source = source(&uri);
         assert!(source.is_some());
 
         let source = source.unwrap();
@@ -108,5 +129,22 @@ mod tests {
         assert_eq!(source.version, "release-76-1");
         assert_eq!(source.homepage, "https://github.com/unicode-org/icu");
         assert_eq!(source.uri, url_str);
+    }
+
+    #[test]
+    fn test_git_repo() {
+        let uri = SourceUri {
+            kind: upstream::Kind::Git,
+            url: Url::parse("https://github.com/rust-lang/rust.git").unwrap(),
+        };
+
+        let source = source(&uri);
+        assert!(source.is_some());
+
+        let source = source.unwrap();
+        assert_eq!(source.name, "rust");
+        assert_eq!(source.version, "UNDETECTED");
+        assert_eq!(source.homepage, "https://github.com/rust-lang/rust");
+        assert_eq!(source.uri, uri.to_string());
     }
 }

--- a/boulder/src/draft/metadata/gitlab.rs
+++ b/boulder/src/draft/metadata/gitlab.rs
@@ -2,28 +2,41 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use regex::Regex;
-use url::Url;
+use stone_recipe::upstream::{self, SourceUri};
 
 use super::Source;
 
-pub fn source(upstream: &Url) -> Option<Source> {
+pub fn source(upstream: &SourceUri) -> Option<Source> {
+    // We only support anonymous access.
+    if upstream.url.username() != "" {
+        return None;
+    }
     // Attempt to match gitlab.com as well as self-hosted gitlab URLs
-    let automatic_regex = Regex::new(
-        r"https\:\/\/([a-z0-9\-\.]+)\/([A-Za-z0-9-_]+)\/([A-Za-z0-9-_]+(?:\/[A-Za-z0-9-_]+)?)\/-\/archive\/([A-Za-z0-9\.\-_]+)\/([A-Za-z0-9-_]+)-([A-Za-z0-9\.\-_]+)\.(tar|gz|bz2|xz)"
-    )
-    .unwrap();
+    if !upstream.url.authority().contains("gitlab") {
+        return None;
+    }
+    // We do not support query parameters or fragments in the URL.
+    if upstream.url.query().is_some() || upstream.url.fragment().is_some() {
+        return None;
+    }
 
-    if let Some(captures) = automatic_regex.captures(upstream.as_str()) {
-        let base_url = captures.get(1)?.as_str();
-
-        if !base_url.contains("gitlab") {
-            return None;
+    let mut path = upstream.url.path();
+    let path_matcher = match upstream.kind {
+        upstream::Kind::Archive => Regex::new(
+            r"([\w-]+)\/([\w.-]+(?:\/[\w.-]+)?)\/-\/archive\/([\w.-]+)\/([\w-]+)-([\w.-]+)\.(?:tar|gz|bz2|xz)",
+        )
+        .unwrap(),
+        upstream::Kind::Git => {
+            path = upstream.url.path().strip_suffix(".git").unwrap_or(&upstream.url.path());
+            Regex::new(r"([\w-]+)\/([\w.-]+(?:\/[\w.-]+)?)").unwrap()
         }
+    };
 
-        let owner = captures.get(2)?.as_str();
-        let project = captures.get(3)?.as_str();
+    if let Some(captures) = path_matcher.captures(path) {
+        let owner = captures.get(1)?.as_str();
+        let project = captures.get(2)?.as_str();
         let canonical_project = project.split_once('/').map(|(_, second)| second).unwrap_or(project);
-        let version = captures.get(4)?.as_str().to_owned();
+        let version = captures.get(3).map_or("UNDETECTED", |v| v.as_str()).to_owned();
 
         // Strip 'v' if the second character is a digit e.g. v1.2.3
         let version =
@@ -36,7 +49,7 @@ pub fn source(upstream: &Url) -> Option<Source> {
         return Some(Source {
             name: canonical_project.to_lowercase(),
             version,
-            homepage: format!("https://{base_url}/{owner}/{project}"),
+            homepage: format!("https://{}/{owner}/{project}", upstream.url.authority()),
             uri: upstream.to_string(),
         });
     }
@@ -52,9 +65,11 @@ mod tests {
     #[test]
     fn test_canonical_gitlab_url() {
         let url_str = "https://gitlab.com/serebit/wraith-master/-/archive/v1.2.1/wraith-master-v1.2.1.tar.bz2";
-        let url = Url::parse(url_str).unwrap();
-
-        let source = source(&url);
+        let uri = SourceUri {
+            kind: upstream::Kind::Archive,
+            url: Url::parse(url_str).unwrap(),
+        };
+        let source = source(&uri);
         assert!(source.is_some());
 
         let source = source.unwrap();
@@ -67,9 +82,12 @@ mod tests {
     #[test]
     fn test_self_hosted_gitlab_url_1() {
         let url_str = "https://gitlab.gnome.org/GNOME/pango/-/archive/1.57.0/pango-1.57.0.tar.gz";
-        let url = Url::parse(url_str).unwrap();
+        let uri = SourceUri {
+            kind: upstream::Kind::Archive,
+            url: Url::parse(url_str).unwrap(),
+        };
 
-        let source = source(&url);
+        let source = source(&uri);
         assert!(source.is_some());
 
         let source = source.unwrap();
@@ -82,9 +100,12 @@ mod tests {
     #[test]
     fn test_self_hosted_gitlab_url_2() {
         let url_str = "https://gitlab.freedesktop.org/serebit/waycheck/-/archive/v1.7.0/waycheck-v1.7.0.tar";
-        let url = Url::parse(url_str).unwrap();
+        let uri = SourceUri {
+            kind: upstream::Kind::Archive,
+            url: Url::parse(url_str).unwrap(),
+        };
 
-        let source = source(&url);
+        let source = source(&uri);
         assert!(source.is_some());
 
         let source = source.unwrap();
@@ -97,9 +118,12 @@ mod tests {
     #[test]
     fn test_self_hosted_gitlab_url_3() {
         let url_str = "https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/archive/xkeyboard-config-2.46/xkeyboard-config-xkeyboard-config-2.46.tar.gz";
-        let url = Url::parse(url_str).unwrap();
+        let uri = SourceUri {
+            kind: upstream::Kind::Archive,
+            url: Url::parse(url_str).unwrap(),
+        };
 
-        let source = source(&url);
+        let source = source(&uri);
         assert!(source.is_some());
 
         let source = source.unwrap();
@@ -117,9 +141,12 @@ mod tests {
     fn test_subproject_in_selfhosted_url() {
         let url_str =
             "https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/archive/v40/mkinitcpio-v40.tar.bz2";
-        let url = Url::parse(url_str).unwrap();
+        let uri = SourceUri {
+            kind: upstream::Kind::Archive,
+            url: Url::parse(url_str).unwrap(),
+        };
 
-        let source = source(&url);
+        let source = source(&uri);
         assert!(source.is_some());
 
         let source = source.unwrap();
@@ -135,9 +162,12 @@ mod tests {
     #[test]
     fn test_version_with_leading_v() {
         let url_str = "https://gitlab.com/serebit/wraith-master/-/archive/v1.2.1/wraith-master-v1.2.1.tar.gz";
-        let url = Url::parse(url_str).unwrap();
+        let uri = SourceUri {
+            kind: upstream::Kind::Archive,
+            url: Url::parse(url_str).unwrap(),
+        };
 
-        let source = source(&url);
+        let source = source(&uri);
         assert!(source.is_some());
 
         let source = source.unwrap();
@@ -150,9 +180,12 @@ mod tests {
     #[test]
     fn test_url_without_version_prefix() {
         let url_str = "https://gitlab.com/serebit/wraith-master/-/archive/1.2.1/wraith-master-1.2.1.tar.gz";
-        let url = Url::parse(url_str).unwrap();
+        let uri = SourceUri {
+            kind: upstream::Kind::Archive,
+            url: Url::parse(url_str).unwrap(),
+        };
 
-        let source = source(&url);
+        let source = source(&uri);
         assert!(source.is_some());
 
         let source = source.unwrap();
@@ -165,18 +198,42 @@ mod tests {
     #[test]
     fn test_avoid_github_url_match() {
         let url_str = "https://github.com/GNOME/pango/archive/refs/tags/1.57.0.tar.gz";
-        let url = Url::parse(url_str).unwrap();
+        let uri = SourceUri {
+            kind: upstream::Kind::Archive,
+            url: Url::parse(url_str).unwrap(),
+        };
 
-        let source = source(&url);
+        let source = source(&uri);
         assert!(source.is_none());
     }
 
     #[test]
     fn test_invalid_url() {
         let url_str = "https://invalid-url.com";
-        let url = Url::parse(url_str).unwrap();
+        let uri = SourceUri {
+            kind: upstream::Kind::Archive,
+            url: Url::parse(url_str).unwrap(),
+        };
 
-        let source = source(&url);
+        let source = source(&uri);
         assert!(source.is_none());
+    }
+
+    #[test]
+    fn test_git_repo() {
+        let url_str = "https://gitlab.freedesktop.org/mesa/mesa3d.org.git";
+        let uri = SourceUri {
+            kind: upstream::Kind::Git,
+            url: Url::parse(url_str).unwrap(),
+        };
+
+        let source = source(&uri);
+        assert!(source.is_some());
+
+        let source = source.unwrap();
+        assert_eq!(source.name, "mesa3d.org");
+        assert_eq!(source.version, "UNDETECTED");
+        assert_eq!(source.homepage, "https://gitlab.freedesktop.org/mesa/mesa3d.org");
+        assert_eq!(source.uri, uri.to_string());
     }
 }

--- a/boulder/src/draft/metadata/metacpan.rs
+++ b/boulder/src/draft/metadata/metacpan.rs
@@ -2,16 +2,20 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use regex::Regex;
-use url::Url;
+use stone_recipe::upstream::SourceUri;
 
 use super::Source;
 
-pub fn source(upstream: &Url) -> Option<Source> {
+pub fn source(upstream: &SourceUri) -> Option<Source> {
+    if !matches!(upstream.kind, stone_recipe::upstream::Kind::Archive) {
+        return None;
+    }
+
     let re = Regex::new(
         r#"^https://cpan\.metacpan\.org/authors/id/[A-Z]/[A-Z]{2}/[A-Z0-9]+/([A-Za-z0-9._+-]+-\d+(?:\.\d+)*)(?:\.tar\.(?:gz|bz2|xz)|\.zip)$"#
     ).unwrap();
 
-    let captures = re.captures(upstream.as_str())?;
+    let captures = re.captures(upstream.url.as_str())?;
 
     let module = captures.get(1)?.as_str().to_owned();
     let parts: Vec<&str> = module.split('-').collect();
@@ -52,9 +56,12 @@ mod tests {
     #[test]
     fn test_regex_typical_metacpan_url() {
         let url_str = "https://cpan.metacpan.org/authors/id/T/TO/TODDR/XML-Parser-2.47.tar.gz";
-        let url = Url::parse(url_str).unwrap();
+        let uri = SourceUri {
+            kind: stone_recipe::upstream::Kind::Archive,
+            url: Url::parse(url_str).unwrap(),
+        };
 
-        let source = source(&url);
+        let source = source(&uri);
         assert!(source.is_some());
 
         let source = source.unwrap();
@@ -62,5 +69,17 @@ mod tests {
         assert_eq!(source.version, "2.47");
         assert_eq!(source.homepage, "https://metacpan.org/pod/XML::Parser");
         assert_eq!(source.uri, url_str);
+    }
+
+    #[test]
+    fn test_git_repo_not_supported() {
+        let url_str = "https://cpan.metacpan.org/authors/id/T/TO/TODDR/XML-Parser-2.47.tar.gz";
+        let uri = SourceUri {
+            kind: stone_recipe::upstream::Kind::Git,
+            url: Url::parse(url_str).unwrap(),
+        };
+
+        let source = source(&uri);
+        assert!(source.is_none());
     }
 }

--- a/boulder/src/draft/metadata/pypi.rs
+++ b/boulder/src/draft/metadata/pypi.rs
@@ -3,19 +3,23 @@
 
 use moss::util;
 use regex::Regex;
-use url::Url;
+use stone_recipe::upstream::SourceUri;
 
 use super::Source;
 
-pub fn source(upstream: &Url) -> Option<Source> {
+pub fn source(upstream: &SourceUri) -> Option<Source> {
+    if !matches!(upstream.kind, stone_recipe::upstream::Kind::Archive) {
+        return None;
+    }
+
     let regex = Regex::new(
         r"^https://files\.pythonhosted\.org/packages/[a-f0-9]{2}/[a-f0-9]{2}/[a-f0-9]+/([^/]+)-([\d.]+)\.tar\.gz$",
     )
     .unwrap();
 
-    let filename = util::uri_file_name(upstream);
+    let filename = util::uri_file_name(&upstream.url);
 
-    let captures = regex.captures(upstream.as_str())?;
+    let captures = regex.captures(upstream.url.as_str())?;
 
     let name = captures.get(1)?.as_str().to_owned();
     let version = captures.get(2)?.as_str().to_owned();
@@ -44,9 +48,12 @@ mod tests {
     #[test]
     fn test_regex_typical_pypi_url() {
         let url_str = "https://files.pythonhosted.org/packages/59/83/a60af4e83c492c7dceceeabd677aa87bbaf2d8910b3d1b973295e560f421/pyzk-0.9.tar.gz";
-        let url = Url::parse(url_str).unwrap();
+        let uri = SourceUri {
+            kind: stone_recipe::upstream::Kind::Archive,
+            url: Url::parse(url_str).unwrap(),
+        };
 
-        let source = source(&url);
+        let source = source(&uri);
         assert!(source.is_some());
 
         let source = source.unwrap();
@@ -57,5 +64,17 @@ mod tests {
             source.uri,
             "https://files.pythonhosted.org/packages/source/p/pyzk/pyzk-0.9.tar.gz"
         );
+    }
+
+    #[test]
+    fn test_git_repo_not_supported() {
+        let url_str = "https://files.pythonhosted.org/packages/59/83/a60af4e83c492c7dceceeabd677aa87bbaf2d8910b3d1b973295e560f421/pyzk-0.9.tar.gz";
+        let uri = SourceUri {
+            kind: stone_recipe::upstream::Kind::Git,
+            url: Url::parse(url_str).unwrap(),
+        };
+
+        let source = source(&uri);
+        assert!(source.is_none());
     }
 }

--- a/boulder/src/draft/upstream.rs
+++ b/boulder/src/draft/upstream.rs
@@ -19,7 +19,7 @@ use crate::Env;
 use crate::upstream::{self, git, plain};
 
 pub struct Upstream {
-    pub uri: Url,
+    pub uri: SourceUri,
     pub hash: String,
 }
 
@@ -34,16 +34,16 @@ pub fn fetch_and_extract(env: &Env, upstreams: &[SourceUri], extract_root: &Path
                 pb.enable_steady_tick(Duration::from_millis(150));
                 let upstream_dir = env.cache_dir.join("upstreams");
 
-                let upstream = match uri.kind {
+                let upstream = match &uri.kind {
                     stone_recipe::upstream::Kind::Archive => {
-                        fetch_and_extract_archive(&uri.url, &upstream_dir, extract_root, &pb).await?
+                        fetch_and_extract_archive(&uri.clone(), &upstream_dir, extract_root, &pb).await?
                     }
                     stone_recipe::upstream::Kind::Git => {
-                        fetch_git_repo(&uri.url, &upstream_dir, extract_root, &pb).await?
+                        fetch_git_repo(&uri.clone(), &upstream_dir, extract_root, &pb).await?
                     }
                 };
 
-                pb.suspend(|| println!("{} {}", "Fetched".green(), *uri));
+                pb.suspend(|| println!("{} {}", "Fetched".green(), uri.url));
 
                 Ok(upstream)
             })
@@ -73,18 +73,18 @@ pub fn fetched_upstream_cache_path(env: &Env, uri: &Url, hash: &str) -> PathBuf 
 }
 
 async fn fetch_and_extract_archive(
-    url: &Url,
+    uri: &SourceUri,
     upstreams_dir: &Path,
     extract_root: &Path,
     pb: &ProgressBar,
 ) -> Result<Upstream, Error> {
     let temp_path = NamedTempFile::with_prefix("boulder-")?.into_temp_path();
 
-    let hash = plain::fetch(url.clone(), &temp_path, pb)
+    let hash = plain::fetch(uri.url.clone(), &temp_path, pb)
         .await
         .map_err(upstream::Error::from)?;
     let archive = plain::Plain {
-        url: url.clone(),
+        url: uri.url.clone(),
         hash,
         rename: None,
     };
@@ -99,27 +99,27 @@ async fn fetch_and_extract_archive(
         util::async_hardlink_or_copy(&temp_path, &final_path).await?;
     }
 
-    pb.set_message(format!("{} {}", "Extracting".yellow(), *url));
+    pb.set_message(format!("{} {}", "Extracting".yellow(), *uri));
     extract_archive(&temp_path, extract_root).await?;
 
     Ok(Upstream {
-        uri: archive.url,
+        uri: uri.clone(),
         hash: archive.hash.to_string(),
     })
 }
 
 async fn fetch_git_repo(
-    url: &Url,
+    uri: &SourceUri,
     upstreams_dir: &Path,
     extract_root: &Path,
     pb: &ProgressBar,
 ) -> Result<Upstream, Error> {
     let git_upstream = git::Git {
-        url: url.clone(),
+        url: uri.url.clone(),
         commit: "HEAD".to_owned(),
         original_index: 0,
     };
-    let repo = git::clone_mirror(url, &git_upstream.stored_path(upstreams_dir), pb)
+    let repo = git::clone_mirror(&uri.url, &git_upstream.stored_path(upstreams_dir), pb)
         .await
         .map_err(|e| upstream::Error::from(git::Error::Git(e)))?;
 
@@ -131,7 +131,7 @@ async fn fetch_git_repo(
         .map_err(|e| upstream::Error::from(git::Error::Git(e)))?;
 
     Ok(Upstream {
-        uri: git_upstream.url,
+        uri: uri.clone(),
         hash: repo
             .peel_commit(&git_upstream.commit)
             .await

--- a/boulder/src/draft/upstream.rs
+++ b/boulder/src/draft/upstream.rs
@@ -1,24 +1,22 @@
 // SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
-use std::{
-    io,
-    path::{Path, PathBuf},
-    process::ExitStatus,
-    time::Duration,
-};
+use std::path::PathBuf;
+use std::{io, path::Path, process::ExitStatus, time::Duration};
 
 use fs_err::tokio::{self as fs};
 use futures_util::{StreamExt, TryStreamExt, stream};
-use moss::{environment, request, runtime, util};
+use moss::{environment, runtime, util};
 use sha2::{Digest, Sha256};
+use stone_recipe::upstream::SourceUri;
 use tempfile::NamedTempFile;
 use thiserror::Error;
 use tokio::process::Command;
-use tui::{MultiProgress, ProgressBar, ProgressStyle, Styled};
+use tui::{MultiProgress, ProgressBar, Styled};
 use url::Url;
 
 use crate::Env;
+use crate::upstream::{self, git, plain};
 
 pub struct Upstream {
     pub uri: Url,
@@ -26,49 +24,28 @@ pub struct Upstream {
 }
 
 /// Fetch and extract the provided upstreams under `extract_root`
-pub fn fetch_and_extract(env: &Env, upstreams: &[Url], extract_root: &Path) -> Result<Vec<Upstream>, Error> {
+pub fn fetch_and_extract(env: &Env, upstreams: &[SourceUri], extract_root: &Path) -> Result<Vec<Upstream>, Error> {
     let mpb = MultiProgress::new();
 
     let ret = runtime::block_on(
         stream::iter(upstreams)
             .map(|uri| async {
-                let temp_path = NamedTempFile::with_prefix("boulder-")?.into_temp_path();
-
-                let pb = mpb.add(
-                    ProgressBar::new_spinner()
-                        .with_style(
-                            ProgressStyle::with_template(" {spinner} {wide_msg}")
-                                .unwrap()
-                                .tick_chars("--=≡■≡=--"),
-                        )
-                        .with_message(format!("{} {}", "Downloading".blue(), *uri)),
-                );
+                let pb = mpb.add(ProgressBar::new_spinner());
                 pb.enable_steady_tick(Duration::from_millis(150));
+                let upstream_dir = env.cache_dir.join("upstreams");
 
-                let hash = request::download_with_sha256(uri.clone(), &temp_path).await?;
-
-                // Hardlink or copy fetched asset to cache dir so we don't need
-                // to refetch it when the user finally builds this new recipe
-                {
-                    let cache_path = fetched_upstream_cache_path(env, uri, &hash);
-
-                    if let Some(parent) = cache_path.parent() {
-                        fs::create_dir_all(parent).await?;
+                let upstream = match uri.kind {
+                    stone_recipe::upstream::Kind::Archive => {
+                        fetch_and_extract_archive(&uri.url, &upstream_dir, extract_root, &pb).await?
                     }
-
-                    util::async_hardlink_or_copy(&temp_path, &cache_path).await?;
-                }
-
-                pb.set_message(format!("{} {}", "Extracting".yellow(), *uri));
-
-                extract(&temp_path, extract_root).await?;
-
-                // Cleanup temp path
-                drop(temp_path);
+                    stone_recipe::upstream::Kind::Git => {
+                        fetch_git_repo(&uri.url, &upstream_dir, extract_root, &pb).await?
+                    }
+                };
 
                 pb.suspend(|| println!("{} {}", "Fetched".green(), *uri));
 
-                Ok(Upstream { uri: uri.clone(), hash })
+                Ok(upstream)
             })
             .buffer_unordered(environment::MAX_NETWORK_CONCURRENCY)
             .try_collect(),
@@ -77,23 +54,6 @@ pub fn fetch_and_extract(env: &Env, upstreams: &[Url], extract_root: &Path) -> R
     println!();
 
     ret
-}
-
-async fn extract(archive: &Path, destination: &Path) -> Result<(), Error> {
-    let result = Command::new("bsdtar")
-        .arg("xf")
-        .arg(archive)
-        .arg("-C")
-        .arg(destination)
-        .output()
-        .await
-        .map_err(Error::Bsdtar)?;
-    if result.status.success() {
-        Ok(())
-    } else {
-        eprintln!("Command exited with: {}", String::from_utf8_lossy(&result.stderr));
-        Err(Error::Extract(result.status))
-    }
 }
 
 pub fn fetched_upstream_cache_path(env: &Env, uri: &Url, hash: &str) -> PathBuf {
@@ -112,14 +72,99 @@ pub fn fetched_upstream_cache_path(env: &Env, uri: &Url, hash: &str) -> PathBuf 
         .join(hash)
 }
 
+async fn fetch_and_extract_archive(
+    url: &Url,
+    upstreams_dir: &Path,
+    extract_root: &Path,
+    pb: &ProgressBar,
+) -> Result<Upstream, Error> {
+    let temp_path = NamedTempFile::with_prefix("boulder-")?.into_temp_path();
+
+    let hash = plain::fetch(url.clone(), &temp_path, pb)
+        .await
+        .map_err(upstream::Error::from)?;
+    let archive = plain::Plain {
+        url: url.clone(),
+        hash,
+        rename: None,
+    };
+
+    // Hardlink or copy fetched asset to cache dir so we don't need
+    // to refetch it when the user finally builds this new recipe.
+    {
+        let final_path = archive.stored_path(upstreams_dir);
+        if let Some(parent) = final_path.parent() {
+            fs::create_dir_all(parent).await?;
+        }
+        util::async_hardlink_or_copy(&temp_path, &final_path).await?;
+    }
+
+    pb.set_message(format!("{} {}", "Extracting".yellow(), *url));
+    extract_archive(&temp_path, extract_root).await?;
+
+    Ok(Upstream {
+        uri: archive.url,
+        hash: archive.hash.to_string(),
+    })
+}
+
+async fn fetch_git_repo(
+    url: &Url,
+    upstreams_dir: &Path,
+    extract_root: &Path,
+    pb: &ProgressBar,
+) -> Result<Upstream, Error> {
+    let git_upstream = git::Git {
+        url: url.clone(),
+        commit: "HEAD".to_owned(),
+        original_index: 0,
+    };
+    let repo = git::clone_mirror(url, &git_upstream.stored_path(upstreams_dir), pb)
+        .await
+        .map_err(|e| upstream::Error::from(git::Error::Git(e)))?;
+
+    // A mirror repository does not write actual source files
+    // in the filesystem. A "regular" repository does, so we clone
+    // the mirror into extract_root.
+    repo.clone_to(extract_root)
+        .await
+        .map_err(|e| upstream::Error::from(git::Error::Git(e)))?;
+
+    Ok(Upstream {
+        uri: git_upstream.url,
+        hash: repo
+            .peel_commit(&git_upstream.commit)
+            .await
+            .map_err(|e| upstream::Error::from(git::Error::Git(e)))?
+            .to_string(),
+    })
+}
+
+async fn extract_archive(archive: &Path, destination: &Path) -> Result<(), Error> {
+    let result = Command::new("bsdtar")
+        .arg("xf")
+        .arg(archive)
+        .arg("-C")
+        .arg(destination)
+        .output()
+        .await
+        .map_err(Error::Bsdtar)?;
+    if result.status.success() {
+        Ok(())
+    } else {
+        eprintln!("Command exited with: {}", String::from_utf8_lossy(&result.stderr));
+        Err(Error::Extract(result.status))
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("failed to run `bsdtar`")]
     Bsdtar(#[source] io::Error),
     #[error("io")]
     Io(#[from] io::Error),
-    #[error("request")]
-    Request(#[from] request::Error),
+    #[error(transparent)]
+    Fetch(#[from] upstream::Error),
     #[error("extract failed with code {0}")]
     Extract(ExitStatus),
 }

--- a/boulder/src/upstream.rs
+++ b/boulder/src/upstream.rs
@@ -16,8 +16,8 @@ use crate::upstream::{
     plain::{Plain, StoredPlain},
 };
 
-mod git;
-mod plain;
+pub(crate) mod git;
+pub(crate) mod plain;
 
 /// An upstream is a backend where
 /// to get source code from.

--- a/boulder/src/upstream/git.rs
+++ b/boulder/src/upstream/git.rs
@@ -12,6 +12,16 @@ use thiserror::Error;
 use tui::{ProgressBar, ProgressStyle};
 use url::Url;
 
+/// Downloads the Git repository inside the container directory.
+pub async fn clone(url: &Url, path: &Path, pb: &ProgressBar) -> Result<gitwrap::Repository, gitwrap::Error> {
+    let cb = set_progress_bar_style(pb);
+
+    let result = gitwrap::Repository::clone_mirror_progress(path, url, cb).await;
+    pb.finish_and_clear();
+
+    result
+}
+
 /// Upstream based on a Git repository.
 #[derive(Clone, Debug)]
 pub struct Git {
@@ -169,15 +179,6 @@ pub enum Error {
     /// A generic I/O error occurred.
     #[error("{0}")]
     Io(#[from] io::Error),
-}
-
-async fn clone(url: &Url, path: &Path, pb: &ProgressBar) -> Result<gitwrap::Repository, gitwrap::Error> {
-    let cb = set_progress_bar_style(pb);
-
-    let result = gitwrap::Repository::clone_mirror_progress(path, url, cb).await;
-    pb.finish_and_clear();
-
-    result
 }
 
 async fn fetch(repo: &gitwrap::Repository, pb: &ProgressBar) -> Result<(), gitwrap::Error> {

--- a/boulder/src/upstream/git.rs
+++ b/boulder/src/upstream/git.rs
@@ -13,7 +13,11 @@ use tui::{ProgressBar, ProgressStyle};
 use url::Url;
 
 /// Downloads the Git repository inside the container directory.
-pub async fn clone(url: &Url, container_dir: &Path, pb: &ProgressBar) -> Result<gitwrap::Repository, gitwrap::Error> {
+pub async fn clone_mirror(
+    url: &Url,
+    container_dir: &Path,
+    pb: &ProgressBar,
+) -> Result<gitwrap::Repository, gitwrap::Error> {
     let cb = set_progress_bar_style(pb);
 
     let result = gitwrap::Repository::clone_mirror_progress(container_dir, url, cb).await;
@@ -55,7 +59,7 @@ impl Git {
             Err(Error::Git(_)) => {
                 cached = false;
                 self.remove(storage_dir)?;
-                repo = clone(&self.url, &self.stored_path(storage_dir), pb).await?;
+                repo = clone_mirror(&self.url, &self.stored_path(storage_dir), pb).await?;
             }
             Err(Error::Io(e)) => return Err(Error::from(e)),
         }

--- a/boulder/src/upstream/git.rs
+++ b/boulder/src/upstream/git.rs
@@ -13,10 +13,10 @@ use tui::{ProgressBar, ProgressStyle};
 use url::Url;
 
 /// Downloads the Git repository inside the container directory.
-pub async fn clone(url: &Url, path: &Path, pb: &ProgressBar) -> Result<gitwrap::Repository, gitwrap::Error> {
+pub async fn clone(url: &Url, container_dir: &Path, pb: &ProgressBar) -> Result<gitwrap::Repository, gitwrap::Error> {
     let cb = set_progress_bar_style(pb);
 
-    let result = gitwrap::Repository::clone_mirror_progress(path, url, cb).await;
+    let result = gitwrap::Repository::clone_mirror_progress(container_dir, url, cb).await;
     pb.finish_and_clear();
 
     result
@@ -111,7 +111,7 @@ impl Git {
 
     /// Returns a relative PathBuf where this Git repository
     /// should be stored within the storage directory.
-    fn stored_path(&self, storage_dir: &Path) -> PathBuf {
+    pub fn stored_path(&self, storage_dir: &Path) -> PathBuf {
         storage_dir.join("git").join(self.directory_name())
     }
 

--- a/boulder/src/upstream/git.rs
+++ b/boulder/src/upstream/git.rs
@@ -9,7 +9,7 @@ use std::{
 use fs_err as fs;
 use moss::util;
 use thiserror::Error;
-use tui::{ProgressBar, ProgressStyle};
+use tui::{ProgressBar, ProgressStyle, Styled};
 use url::Url;
 
 /// Downloads the Git repository inside the container directory.
@@ -19,6 +19,7 @@ pub async fn clone_mirror(
     pb: &ProgressBar,
 ) -> Result<gitwrap::Repository, gitwrap::Error> {
     let cb = set_progress_bar_style(pb);
+    pb.set_message(format!("{} {}", "Cloning".blue(), url));
 
     let result = gitwrap::Repository::clone_mirror_progress(container_dir, url, cb).await;
     pb.finish_and_clear();
@@ -187,6 +188,7 @@ pub enum Error {
 
 async fn fetch(repo: &gitwrap::Repository, pb: &ProgressBar) -> Result<(), gitwrap::Error> {
     let cb = set_progress_bar_style(pb);
+    pb.set_message("Fetching".blue().to_string());
 
     let result = repo.fetch_progress(cb).await;
     pb.finish_and_clear();

--- a/boulder/src/upstream/plain.rs
+++ b/boulder/src/upstream/plain.rs
@@ -15,6 +15,27 @@ use thiserror::Error;
 use tui::{ProgressBar, ProgressStyle};
 use url::Url;
 
+/// Downloads the source archive into the desired file path and returns
+/// its hash.
+///
+/// Do note that the hash may be incorrect, e.g. because of network issues.
+/// It is advised to check the hash against a known value afterwards.
+pub async fn fetch(url: Url, file_path: &Path, pb: &ProgressBar) -> Result<Hash, Error> {
+    pb.set_style(
+        ProgressStyle::with_template(" {spinner} {wide_msg} {binary_bytes_per_sec:>.dim} ")
+            .unwrap()
+            .tick_chars("--=≡■≡=--"),
+    );
+
+    let hash = request::download_with_progress_and_sha256(url.clone(), file_path, |progress| pb.inc(progress.delta))
+        .await
+        .map_err(Error::from)?
+        .try_into()
+        .map_err(Error::from)?;
+
+    Ok(hash)
+}
+
 /// Upstream based on an archive (typically a tarball).
 #[derive(Debug, Clone)]
 pub struct Plain {
@@ -147,7 +168,7 @@ pub struct StoredPlain {
     pub name: String,
     /// Path of the source archive after it was stored.
     pub path: PathBuf,
-    /// Whether the source archived was already stored with valid hash.
+    /// Whether the source archive was already stored with valid hash.
     pub was_cached: bool,
 }
 
@@ -226,18 +247,4 @@ pub enum Error {
     #[error("io")]
     /// A generic I/O error occurred.
     Io(#[from] io::Error),
-}
-
-async fn fetch(url: Url, dest: &Path, pb: &ProgressBar) -> Result<Hash, Error> {
-    pb.set_style(
-        ProgressStyle::with_template(" {spinner} {wide_msg} {binary_bytes_per_sec:>.dim} ")
-            .unwrap()
-            .tick_chars("--=≡■≡=--"),
-    );
-
-    request::download_with_progress_and_sha256(url, dest, |progress| pb.inc(progress.delta))
-        .await
-        .map_err(Error::from)?
-        .try_into()
-        .map_err(Error::from)
 }

--- a/boulder/src/upstream/plain.rs
+++ b/boulder/src/upstream/plain.rs
@@ -12,7 +12,7 @@ use fs_err as fs;
 use moss::{request, util};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
-use tui::{ProgressBar, ProgressStyle};
+use tui::{ProgressBar, ProgressStyle, Styled};
 use url::Url;
 
 /// Downloads the source archive into the desired file path and returns
@@ -26,6 +26,7 @@ pub async fn fetch(url: Url, file_path: &Path, pb: &ProgressBar) -> Result<Hash,
             .unwrap()
             .tick_chars("--=≡■≡=--"),
     );
+    pb.set_message(format!("{} {}", "Downloading".blue(), url));
 
     let hash = request::download_with_progress_and_sha256(url.clone(), file_path, |progress| pb.inc(progress.delta))
         .await

--- a/boulder/src/upstream/plain.rs
+++ b/boulder/src/upstream/plain.rs
@@ -141,7 +141,7 @@ impl Plain {
 
     /// Returns a relative PathBuf where this source archive
     /// should be stored within the storage directory.
-    fn stored_path(&self, storage_dir: &Path) -> PathBuf {
+    pub fn stored_path(&self, storage_dir: &Path) -> PathBuf {
         storage_dir.join("fetched").join(self.file_path())
     }
 


### PR DESCRIPTION
This PR makes the `boulder recipe new` command accept Git-styled URI to create a recipe out of a Git repository. a Git-styled URI is a regular URL prefixed with our `git|` specifier. The recipe created points to the hash of the current HEAD of the repo.

I've also simplified URL parsing in `draft::monitoring::github` and `draft::monitoring::gitlab`, as in my opinion the regexes were hard to grasp. We're still leveraging regexes (although ideally we would ditch them), but they're shorter and only match the path inside the URL. Other checks are performed using functions provided by the `Url` struct.\
No functional change is introduced in these two modules *except* in gitlab's regular expressions, because the original ones weren't matching projects with a dot (".") in their name. In fact, I've also created a test with [mesa3d.org's URL](https://gitlab.freedesktop.org/mesa/mesa3d.org).

There's one effort remaining that is not covered in this PR: when running `boulder recipe new <first_url> <second_url>`, the command eventually fails because under the hood Git is trying to clone a repo inside the extraction root, that is not empty. Git is not happy about this. #838 will cover this case.

Fixes #537.