### PR TITLE
Ask for confirmation when `boulder recipe new` is passed multiple upstreams

### DIFF
--- a/boulder/src/cli/recipe.rs
+++ b/boulder/src/cli/recipe.rs
@@ -8,7 +8,7 @@ use std::{
 
 use crate::{
     Env, Macros, architecture,
-    draft::{self, Drafter, upstream::fetched_upstream_cache_path},
+    draft::{self, Confirmation, Drafter, upstream::fetched_upstream_cache_path},
     macros, recipe,
 };
 use clap::Parser;
@@ -119,7 +119,12 @@ fn parse_updated_source(s: &str) -> Result<UpdatedSource, String> {
 pub fn handle(command: Command, env: Env, yes: bool, verbose: bool) -> Result<(), Error> {
     match command.subcommand {
         Subcommand::Bump { recipe, release } => bump(recipe, release),
-        Subcommand::New { output, upstreams } => new(env, output, upstreams),
+        Subcommand::New { output, upstreams } => new(
+            env,
+            output,
+            upstreams,
+            if yes { Confirmation::DoNotAsk } else { Confirmation::Ask },
+        ),
         Subcommand::Update {
             recipe,
             output,
@@ -281,12 +286,12 @@ fn bump(recipe: PathBuf, release: Option<u64>) -> Result<(), Error> {
     Ok(())
 }
 
-fn new(env: Env, output: PathBuf, upstreams: Vec<SourceUri>) -> Result<(), Error> {
+fn new(env: Env, output: PathBuf, upstreams: Vec<SourceUri>, confirm: Confirmation) -> Result<(), Error> {
     const RECIPE_FILE: &str = "stone.yaml";
     const MONITORING_FILE: &str = "monitoring.yaml";
 
     let drafter = Drafter::new(env, upstreams);
-    let draft = drafter.run()?;
+    let draft = drafter.run(confirm)?;
 
     if !output.is_dir() {
         fs::create_dir_all(&output).map_err(Error::CreateDir)?;

--- a/boulder/src/draft.rs
+++ b/boulder/src/draft.rs
@@ -68,7 +68,7 @@ impl Drafter {
             }
         }
 
-        runtime::block_on(upstream::extract(&self.env, &upstreams.first().unwrap(), extract_root))?;
+        upstream::extract(&self.env, upstreams.first().unwrap(), extract_root)?;
 
         // Build metadata from extracted upstreams
         let metadata = Metadata::new(upstreams);

--- a/boulder/src/draft.rs
+++ b/boulder/src/draft.rs
@@ -16,7 +16,6 @@ use crate::Env;
 
 use self::metadata::Metadata;
 use self::monitoring::Monitoring;
-use self::upstream::Upstream;
 
 mod build;
 mod licenses;
@@ -26,7 +25,7 @@ pub mod upstream;
 
 pub struct Drafter {
     env: Env,
-    upstreams: Vec<SourceUri>,
+    source_uris: Vec<SourceUri>,
 }
 
 pub struct Draft {
@@ -35,19 +34,20 @@ pub struct Draft {
 }
 
 impl Drafter {
-    pub fn new(env: Env, upstreams: Vec<SourceUri>) -> Self {
-        Self { env, upstreams }
+    pub fn new(env: Env, source_uris: Vec<SourceUri>) -> Self {
+        Self { env, source_uris }
     }
 
     pub fn run(&self) -> Result<Draft, Error> {
         let temp_dir = tempfile::tempdir()?;
         let extract_root = temp_dir.as_ref();
 
-        // Fetch and extract all upstreams
-        let extracted = upstream::fetch_and_extract(&self.env, &self.upstreams, extract_root)?;
+        // Fetch upstreams and extract the first one.
+        let upstreams = upstream::fetch(&self.env, &self.source_uris)?;
+        runtime::block_on(upstream::extract(&self.env, &upstreams.first().unwrap(), extract_root))?;
 
         // Build metadata from extracted upstreams
-        let metadata = Metadata::new(extracted);
+        let metadata = Metadata::new(upstreams);
 
         let monitoring = Monitoring::new(&metadata.source.name, &metadata.source.homepage);
         let monitoring_result = monitoring.run()?;
@@ -173,7 +173,7 @@ pub enum Error {
     #[error("analyzing build system")]
     AnalyzeBuildSystem(#[source] build::Error),
     #[error("upstream")]
-    Upstream(#[from] upstream::Error),
+    Upstream(#[from] crate::upstream::Error),
     #[error("monitoring")]
     Monitoring(#[from] monitoring::Error),
     #[error("licensing")]

--- a/boulder/src/draft.rs
+++ b/boulder/src/draft.rs
@@ -10,7 +10,10 @@ use licenses::match_licences;
 use moss::{Dependency, util};
 use stone_recipe::upstream::SourceUri;
 use thiserror::Error;
-use tui::Styled;
+use tui::{
+    Styled,
+    dialoguer::{Confirm, theme::ColorfulTheme},
+};
 
 use crate::Env;
 
@@ -28,6 +31,11 @@ pub struct Drafter {
     source_uris: Vec<SourceUri>,
 }
 
+pub enum Confirmation {
+    Ask,
+    DoNotAsk,
+}
+
 pub struct Draft {
     pub stone: String,
     pub monitoring: String,
@@ -38,12 +46,28 @@ impl Drafter {
         Self { env, source_uris }
     }
 
-    pub fn run(&self) -> Result<Draft, Error> {
+    pub fn run(&self, confirm: Confirmation) -> Result<Draft, Error> {
         let temp_dir = tempfile::tempdir()?;
         let extract_root = temp_dir.as_ref();
 
         // Fetch upstreams and extract the first one.
         let upstreams = upstream::fetch(&self.env, &self.source_uris)?;
+
+        if upstreams.len() > 1 {
+            let proceed = matches!(confirm, Confirmation::DoNotAsk)
+                || Confirm::with_theme(&ColorfulTheme::default())
+                    .with_prompt(
+                        "Multiple upstreams passed, only the first one will be extracted and analyzed. Continue?",
+                    )
+                    .default(false)
+                    .wait_for_newline(true)
+                    .interact()
+                    .map_err(|e| Error::Io(e.into()))?;
+            if !proceed {
+                return Err(Error::Aborted);
+            }
+        }
+
         runtime::block_on(upstream::extract(&self.env, &upstreams.first().unwrap(), extract_root))?;
 
         // Build metadata from extracted upstreams
@@ -182,6 +206,8 @@ pub enum Error {
     Io(#[from] io::Error),
     #[error("walkdir")]
     WalkDir(#[from] walkdir::Error),
+    #[error("operation aborted by user")]
+    Aborted,
 }
 
 #[cfg(test)]

--- a/boulder/src/draft/metadata.rs
+++ b/boulder/src/draft/metadata.rs
@@ -3,7 +3,7 @@
 
 use itertools::Itertools;
 
-use super::Upstream;
+use crate::upstream::Upstream;
 
 mod basic;
 mod github;
@@ -31,13 +31,14 @@ impl Metadata {
 
         // Try to identify source metadata from the first upstream
         if let Some(upstream) = upstreams.first() {
+            let uri = upstream.uri();
             for matcher in Matcher::ALL {
                 if let Some(matched) = match matcher {
-                    Matcher::Basic => basic::source(&upstream.uri),
-                    Matcher::Github => github::source(&upstream.uri),
-                    Matcher::Gitlab => gitlab::source(&upstream.uri),
-                    Matcher::Pypi => pypi::source(&upstream.uri),
-                    Matcher::Metacpan => metacpan::source(&upstream.uri),
+                    Matcher::Basic => basic::source(&uri),
+                    Matcher::Github => github::source(&uri),
+                    Matcher::Gitlab => gitlab::source(&uri),
+                    Matcher::Pypi => pypi::source(&uri),
+                    Matcher::Metacpan => metacpan::source(&uri),
                 } {
                     source = matched;
                     break;
@@ -52,12 +53,13 @@ impl Metadata {
         self.upstreams
             .iter()
             .enumerate()
-            .map(|(i, Upstream { uri, hash })| {
+            .map(|(i, upstream)| {
                 let uri_to_use = if i == 0 && !self.source.uri.is_empty() {
                     &self.source.uri
                 } else {
-                    &uri.to_string()
+                    &upstream.uri().to_string()
                 };
+                let hash = upstream.hash();
                 format!("    - {uri_to_use} : {hash}")
             })
             .join("\n")

--- a/boulder/src/draft/metadata/github.rs
+++ b/boulder/src/draft/metadata/github.rs
@@ -26,7 +26,7 @@ pub fn source(upstream: &SourceUri) -> Option<Source> {
     };
 
     for matcher in path_matchers {
-        let Some(captures) = matcher.captures(&upstream.url.path()) else {
+        let Some(captures) = matcher.captures(upstream.url.path()) else {
             continue;
         };
 

--- a/boulder/src/draft/metadata/gitlab.rs
+++ b/boulder/src/draft/metadata/gitlab.rs
@@ -27,7 +27,7 @@ pub fn source(upstream: &SourceUri) -> Option<Source> {
         )
         .unwrap(),
         upstream::Kind::Git => {
-            path = upstream.url.path().strip_suffix(".git").unwrap_or(&upstream.url.path());
+            path = upstream.url.path().strip_suffix(".git").unwrap_or(upstream.url.path());
             Regex::new(r"([\w-]+)\/([\w.-]+(?:\/[\w.-]+)?)").unwrap()
         }
     };

--- a/boulder/src/draft/upstream.rs
+++ b/boulder/src/draft/upstream.rs
@@ -2,29 +2,24 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use std::path::PathBuf;
-use std::{io, path::Path, process::ExitStatus, time::Duration};
+use std::{path::Path, time::Duration};
 
 use fs_err::tokio::{self as fs};
 use futures_util::{StreamExt, TryStreamExt, stream};
 use moss::{environment, runtime, util};
 use sha2::{Digest, Sha256};
+use stone_recipe::upstream::Kind as SourceKind;
 use stone_recipe::upstream::SourceUri;
 use tempfile::NamedTempFile;
-use thiserror::Error;
-use tokio::process::Command;
+
 use tui::{MultiProgress, ProgressBar, Styled};
 use url::Url;
 
 use crate::Env;
-use crate::upstream::{self, git, plain};
+use crate::upstream::{Error, Upstream, git, plain};
 
-pub struct Upstream {
-    pub uri: SourceUri,
-    pub hash: String,
-}
-
-/// Fetch and extract the provided upstreams under `extract_root`
-pub fn fetch_and_extract(env: &Env, upstreams: &[SourceUri], extract_root: &Path) -> Result<Vec<Upstream>, Error> {
+/// Fetches a list of upstreams and stores them into the cache directory on success.
+pub fn fetch(env: &Env, upstreams: &[SourceUri]) -> Result<Vec<Upstream>, Error> {
     let mpb = MultiProgress::new();
 
     let ret = runtime::block_on(
@@ -35,12 +30,8 @@ pub fn fetch_and_extract(env: &Env, upstreams: &[SourceUri], extract_root: &Path
                 let upstream_dir = env.cache_dir.join("upstreams");
 
                 let upstream = match &uri.kind {
-                    stone_recipe::upstream::Kind::Archive => {
-                        fetch_and_extract_archive(&uri.clone(), &upstream_dir, extract_root, &pb).await?
-                    }
-                    stone_recipe::upstream::Kind::Git => {
-                        fetch_git_repo(&uri.clone(), &upstream_dir, extract_root, &pb).await?
-                    }
+                    SourceKind::Archive => fetch_archive(&uri.clone(), &upstream_dir, &pb).await?,
+                    SourceKind::Git => fetch_git_repo(&uri.clone(), &upstream_dir, &pb).await?,
                 };
 
                 pb.suspend(|| println!("{} {}", "Fetched".green(), uri.url));
@@ -56,7 +47,28 @@ pub fn fetch_and_extract(env: &Env, upstreams: &[SourceUri], extract_root: &Path
     ret
 }
 
+/// Extracts the upstream into the destination directory.
+/// The destination directory must exist.
+pub fn extract(env: &Env, upstream: &Upstream, extract_root: &Path) -> Result<(), Error> {
+    let upstream_container_dir = env.cache_dir.join("upstreams");
+    let upstream_dir = upstream.stored_path(&upstream_container_dir);
+    runtime::block_on(async {
+        match upstream {
+            Upstream::Plain(_) => plain::extract(&upstream_dir, extract_root).await.map_err(Error::from),
+            Upstream::Git(_) => git::clone_to(&upstream_dir, extract_root)
+                .await
+                .map_err(|e| Error::from(git::Error::Git(e))),
+        }
+    })?;
+    Ok(())
+}
+
 pub fn fetched_upstream_cache_path(env: &Env, uri: &Url, hash: &str) -> PathBuf {
+    // FIXME: contrary to the other functions here,
+    // this function *knows* too much, because it was left intact after a refactor
+    // (as it was out of the scope of the refactor).
+    // It should eventually be stripped as well.
+
     let mut hasher = Sha256::new();
     hasher.update(uri.as_str());
     hasher.update(hash);
@@ -72,99 +84,46 @@ pub fn fetched_upstream_cache_path(env: &Env, uri: &Url, hash: &str) -> PathBuf 
         .join(hash)
 }
 
-async fn fetch_and_extract_archive(
-    uri: &SourceUri,
-    upstreams_dir: &Path,
-    extract_root: &Path,
-    pb: &ProgressBar,
-) -> Result<Upstream, Error> {
+async fn fetch_archive(uri: &SourceUri, upstreams_dir: &Path, pb: &ProgressBar) -> Result<Upstream, Error> {
     let temp_path = NamedTempFile::with_prefix("boulder-")?.into_temp_path();
 
-    let hash = plain::fetch(uri.url.clone(), &temp_path, pb)
-        .await
-        .map_err(upstream::Error::from)?;
+    let hash = plain::fetch(uri.url.clone(), &temp_path, pb).await?;
     let archive = plain::Plain {
         url: uri.url.clone(),
         hash,
         rename: None,
     };
 
-    // Hardlink or copy fetched asset to cache dir so we don't need
-    // to refetch it when the user finally builds this new recipe.
-    {
-        let final_path = archive.stored_path(upstreams_dir);
-        if let Some(parent) = final_path.parent() {
-            fs::create_dir_all(parent).await?;
-        }
-        util::async_hardlink_or_copy(&temp_path, &final_path).await?;
+    let final_path = archive.stored_path(upstreams_dir);
+    if let Some(parent) = final_path.parent() {
+        fs::create_dir_all(parent).await?;
     }
+    util::async_hardlink_or_copy(&temp_path, &final_path).await?;
 
-    pb.set_message(format!("{} {}", "Extracting".yellow(), *uri));
-    extract_archive(&temp_path, extract_root).await?;
-
-    Ok(Upstream {
-        uri: uri.clone(),
-        hash: archive.hash.to_string(),
-    })
+    Ok(Upstream::Plain(archive))
 }
 
-async fn fetch_git_repo(
-    uri: &SourceUri,
-    upstreams_dir: &Path,
-    extract_root: &Path,
-    pb: &ProgressBar,
-) -> Result<Upstream, Error> {
-    let git_upstream = git::Git {
+async fn fetch_git_repo(uri: &SourceUri, upstreams_dir: &Path, pb: &ProgressBar) -> Result<Upstream, Error> {
+    let mut git_upstream = git::Git {
         url: uri.url.clone(),
         commit: "HEAD".to_owned(),
         original_index: 0,
     };
+    let final_path = git_upstream.stored_path(upstreams_dir);
+
+    // git::clone_mirror() will fail if the path exists, but
+    // fetch_archive() happily overwrites final_path if it exists:
+    // replicate the same behavior here.
+    util::remove_dir_all(&final_path)?;
+
     let repo = git::clone_mirror(&uri.url, &git_upstream.stored_path(upstreams_dir), pb)
         .await
-        .map_err(|e| upstream::Error::from(git::Error::Git(e)))?;
+        .map_err(|e| Error::from(git::Error::Git(e)))?;
 
-    // A mirror repository does not write actual source files
-    // in the filesystem. A "regular" repository does, so we clone
-    // the mirror into extract_root.
-    repo.clone_to(extract_root)
+    git_upstream.commit = repo
+        .peel_commit(&git_upstream.commit)
         .await
-        .map_err(|e| upstream::Error::from(git::Error::Git(e)))?;
+        .map_err(|e| Error::from(git::Error::Git(e)))?;
 
-    Ok(Upstream {
-        uri: uri.clone(),
-        hash: repo
-            .peel_commit(&git_upstream.commit)
-            .await
-            .map_err(|e| upstream::Error::from(git::Error::Git(e)))?
-            .to_string(),
-    })
-}
-
-async fn extract_archive(archive: &Path, destination: &Path) -> Result<(), Error> {
-    let result = Command::new("bsdtar")
-        .arg("xf")
-        .arg(archive)
-        .arg("-C")
-        .arg(destination)
-        .output()
-        .await
-        .map_err(Error::Bsdtar)?;
-    if result.status.success() {
-        Ok(())
-    } else {
-        eprintln!("Command exited with: {}", String::from_utf8_lossy(&result.stderr));
-        Err(Error::Extract(result.status))
-    }
-}
-
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("failed to run `bsdtar`")]
-    Bsdtar(#[source] io::Error),
-    #[error("io")]
-    Io(#[from] io::Error),
-    #[error(transparent)]
-    Fetch(#[from] upstream::Error),
-    #[error("extract failed with code {0}")]
-    Extract(ExitStatus),
+    Ok(Upstream::Git(git_upstream))
 }

--- a/boulder/src/upstream.rs
+++ b/boulder/src/upstream.rs
@@ -1,13 +1,32 @@
 // SPDX-FileCopyrightText: 2026 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
 
-use std::{io, path::Path, time::Duration};
+//! This module contains the logic to fetch upstreams from the network
+//! and store them in the storage directory, as well as to share them
+//! with the build containers.
+//!
+//! This module abstracts over different types of upstreams
+//! and provides a unified interface to fetch, store, and share them.
+//! Child modules implement the logic for each type of supported
+//! upstream, so please consult them should you need specific logic
+//! for a given upstream type.
+//! Each child module is organized with structs/enums that provide
+//! a high-level and opinionated interface to fetch, store and share
+//! the upstreams it targets.
+//! It also provides free-standing functions that implement the low-level
+//! and unopinionated logic.
+
+use std::{
+    io,
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use crate::recipe::Recipe;
 use fs_err as fs;
 use futures_util::{StreamExt, TryStreamExt, stream};
 use moss::runtime;
-use stone_recipe::upstream;
+use stone_recipe::upstream::{self, SourceUri};
 use thiserror::Error;
 use tui::{MultiProgress, ProgressBar, ProgressStyle, Styled};
 
@@ -46,6 +65,43 @@ impl Upstream {
                 commit: git_ref,
                 original_index,
             })),
+        }
+    }
+
+    /// Constructs a new [stone_recipe::upstream::SourceUri]
+    /// where this upstream can be fetched from.
+    pub fn uri(&self) -> SourceUri {
+        match self {
+            Upstream::Plain(plain) => SourceUri {
+                url: plain.url.clone(),
+                kind: upstream::Kind::Archive,
+            },
+            Upstream::Git(git) => SourceUri {
+                url: git.url.clone(),
+                kind: upstream::Kind::Git,
+            },
+        }
+    }
+
+    /// Returns the hash of this upstream, as a generic string.
+    /// The meaning of the hash depends on the upstream variant.
+    pub fn hash(&self) -> &str {
+        match self {
+            Upstream::Plain(plain) => &plain.hash,
+            Upstream::Git(git) => &git.commit,
+        }
+    }
+
+    /// Returns the path where this upstream would be stored
+    /// in the storage directory.
+    /// The path may be a file or a directory, depending on
+    /// the upstream variant.
+    /// The path may not exist yet, but it is guaranteed to
+    /// be unique inside the storage directory.
+    pub fn stored_path(&self, storage_dir: &Path) -> PathBuf {
+        match self {
+            Upstream::Plain(plain) => plain.stored_path(storage_dir),
+            Upstream::Git(git) => git.stored_path(storage_dir),
         }
     }
 

--- a/boulder/src/upstream/git.rs
+++ b/boulder/src/upstream/git.rs
@@ -27,6 +27,16 @@ pub async fn clone_mirror(
     result
 }
 
+/// Clones a mirrored Git repository into a destination directory.
+/// The destination directory must be empty.
+/// Contrary to the original mirror, the cloned repository will
+/// contain actual source files in the filesystem.
+pub async fn clone_to(repo_dir: &Path, dest_dir: &Path) -> Result<(), gitwrap::Error> {
+    let repo = gitwrap::Repository::open_bare(repo_dir).await?;
+    repo.clone_to(dest_dir).await?;
+    Ok(())
+}
+
 /// Upstream based on a Git repository.
 #[derive(Clone, Debug)]
 pub struct Git {

--- a/boulder/src/upstream/git.rs
+++ b/boulder/src/upstream/git.rs
@@ -19,7 +19,7 @@ pub async fn clone_mirror(
     pb: &ProgressBar,
 ) -> Result<gitwrap::Repository, gitwrap::Error> {
     let cb = set_progress_bar_style(pb);
-    pb.set_message(format!("{} {}", "Cloning".blue(), url));
+    pb.set_message(format!("{} {url}", "Cloning".blue()));
 
     let result = gitwrap::Repository::clone_mirror_progress(container_dir, url, cb).await;
     pb.finish_and_clear();

--- a/boulder/src/upstream/plain.rs
+++ b/boulder/src/upstream/plain.rs
@@ -12,6 +12,7 @@ use fs_err as fs;
 use moss::{request, util};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
+use tokio::process::Command;
 use tui::{ProgressBar, ProgressStyle, Styled};
 use url::Url;
 
@@ -35,6 +36,19 @@ pub async fn fetch(url: Url, file_path: &Path, pb: &ProgressBar) -> Result<Hash,
         .map_err(Error::from)?;
 
     Ok(hash)
+}
+
+/// Extracts the source archive into the destination directory.
+/// The destination directory must exist.
+pub async fn extract(archive_path: &Path, dest_dir: &Path) -> Result<(), Error> {
+    Command::new("bsdtar")
+        .arg("xf")
+        .arg(archive_path)
+        .arg("-C")
+        .arg(dest_dir)
+        .output()
+        .await?;
+    Ok(())
 }
 
 /// Upstream based on an archive (typically a tarball).

--- a/boulder/src/upstream/plain.rs
+++ b/boulder/src/upstream/plain.rs
@@ -27,7 +27,7 @@ pub async fn fetch(url: Url, file_path: &Path, pb: &ProgressBar) -> Result<Hash,
             .unwrap()
             .tick_chars("--=≡■≡=--"),
     );
-    pb.set_message(format!("{} {}", "Downloading".blue(), url));
+    pb.set_message(format!("{} {url}", "Downloading".blue()));
 
     let hash = request::download_with_progress_and_sha256(url.clone(), file_path, |progress| pb.inc(progress.delta))
         .await


### PR DESCRIPTION
This PR adds some more documentation and functionalities to `crate::upstream` and removes the `Upstream` struct in `draft::upstream`.

It also makes `boulder recipe new` ask for confirmation when multiple upstreams are passed, since only the first one will be scanned for the build system, licenses and dependencies.

Depends on #837, please review and merge that one first.