### PR TITLE
crates/triggers: Support argument expansion with :all/:each

### DIFF
--- a/crates/fnmatch/src/lib.rs
+++ b/crates/fnmatch/src/lib.rs
@@ -115,7 +115,7 @@ pub struct Pattern {
 /// variables, as determined by the [Pattern]
 ///
 /// Generate a Match by calling [`Pattern::match_path()`]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Match {
     pub path: String,
 

--- a/crates/triggers/src/format.rs
+++ b/crates/triggers/src/format.rs
@@ -5,8 +5,12 @@
 // but we don't Ord or Hash off that field
 #![allow(clippy::mutable_key_type)]
 
-use std::{collections::BTreeMap, fmt};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+};
 
+use crate::Error;
 use fnmatch::Pattern;
 use serde::Deserialize;
 
@@ -19,6 +23,14 @@ pub enum PathKind {
 }
 
 /// Execution handlers for a trigger
+///
+/// `run` arguments support variable expansion with explicit modes:
+///
+/// * `$(var)` / `$(var:each)` - one invocation per match value
+/// * `$(var:all)` - Singular invocation for every match's value expanded inline
+///
+/// Bare `$(var)` arguments default to the per-match mode, preserving the
+/// pre-coalescing behaviour for existing triggers.
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(untagged)]
 pub enum Handler {
@@ -57,28 +69,155 @@ impl CompiledHandler {
     }
 }
 
+/// Expansion mode for a variable argument
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VarMode {
+    /// One invocation per distinct match value
+    Each,
+
+    /// Expand every match's value inline into a single invocation
+    All,
+}
+
+/// A parsed trigger argument
+#[derive(Debug, Clone)]
+enum ArgKind {
+    /// Static argument
+    Fixed(String),
+
+    /// $(var) / $(var:each) / $(var:all) arguments
+    Variable { template: String, mode: VarMode },
+}
+
+/// Substitute every $(var), $(var:each) and $(var:all) reference in template
+fn substitute(template: &str, variables: &BTreeMap<String, String>) -> String {
+    let mut result = template.to_owned();
+    for (key, value) in variables {
+        result = result.replace(&format!("$({key})"), value);
+        result = result.replace(&format!("$({key}:each)"), value);
+        result = result.replace(&format!("$({key}:all)"), value);
+    }
+    result
+}
+
+/// Parse an argument into its fixed or variable form
+fn parse_arg(arg: &str) -> Result<ArgKind, Error> {
+    let Some(inner) = arg.strip_prefix("$(").and_then(|s| s.strip_suffix(')')) else {
+        return Ok(ArgKind::Fixed(arg.to_owned()));
+    };
+
+    let mode = match inner.split_once(':') {
+        Some((_, "each")) => VarMode::Each,
+        Some((_, "all")) => VarMode::All,
+        Some((_, other)) => return Err(Error::UnknownArgMode(other.to_owned())),
+        // Bare $(var) behaves like $(var:each) for backwards compatibility
+        None => VarMode::Each,
+    };
+
+    Ok(ArgKind::Variable {
+        template: arg.to_owned(),
+        mode,
+    })
+}
+
 impl Handler {
-    /// Substitute all paths using matched variables
-    pub fn compiled(&self, with_match: &fnmatch::Match) -> CompiledHandler {
+    /// Coalesce multiple matches into as few handler executions as possible
+    ///
+    /// * $(var) / $(var:each) - one invocation per distinct match value
+    /// * $(var:all) - a single invocation with every match's value expanded inline
+    ///
+    /// Fixed (non-variable) arguments are also substituted with the match variables,
+    /// and act as grouping keys when they reference variables, e.g. an argument of
+    /// --version=$(version) results in one invocation per distinct version.
+    pub fn coalesced(&self, matches: &BTreeSet<fnmatch::Match>) -> Result<Vec<CompiledHandler>, Error> {
         match self {
             Handler::Run { run, args } => {
-                let mut run = run.clone();
-                for (key, value) in &with_match.variables {
-                    run = run.replace(&format!("$({key})"), value);
+                if matches.is_empty() {
+                    return Ok(vec![]);
                 }
-                let args = args
-                    .iter()
-                    .map(|a| {
-                        let mut a = a.clone();
-                        for (key, value) in &with_match.variables {
-                            a = a.replace(&format!("$({key})"), value);
+
+                let arg_kinds = args.iter().map(|a| parse_arg(a)).collect::<Result<Vec<_>, _>>()?;
+
+                // Any ":each" argument means one invocation per match, with every
+                // argument substituted using that match's variables
+                let has_each = arg_kinds.iter().any(|k| {
+                    matches!(
+                        k,
+                        ArgKind::Variable {
+                            mode: VarMode::Each,
+                            ..
                         }
-                        a
-                    })
-                    .collect();
-                CompiledHandler(Handler::Run { run, args })
+                    )
+                });
+
+                if has_each {
+                    // Deduplicate identical commands: many matched paths can share
+                    // the same captured variables (e.g. every module path for one
+                    // kernel version), which must not re-run the handler per path
+                    return Ok(matches
+                        .iter()
+                        .map(|m| {
+                            CompiledHandler(Handler::Run {
+                                run: substitute(run, &m.variables),
+                                args: arg_kinds
+                                    .iter()
+                                    .map(|kind| match kind {
+                                        ArgKind::Fixed(template) => substitute(template, &m.variables),
+                                        ArgKind::Variable { template, .. } => substitute(template, &m.variables),
+                                    })
+                                    .collect(),
+                            })
+                        })
+                        .collect::<BTreeSet<_>>()
+                        .into_iter()
+                        .collect());
+                }
+
+                // All variable arguments are ":all": group matches by the fixed shape
+                // of the command (substituted run + fixed args), then expand the ":all"
+                // arguments per match within each group, preserving value pairing
+                let mut groups: BTreeMap<(String, Vec<String>), Vec<&fnmatch::Match>> = BTreeMap::new();
+                for m in matches {
+                    let key = (
+                        substitute(run, &m.variables),
+                        arg_kinds
+                            .iter()
+                            .filter_map(|kind| match kind {
+                                ArgKind::Fixed(template) => Some(substitute(template, &m.variables)),
+                                ArgKind::Variable { .. } => None,
+                            })
+                            .collect(),
+                    );
+                    groups.entry(key).or_default().push(m);
+                }
+
+                let mut results = Vec::new();
+                for ((final_run, fixed_args), group_matches) in groups {
+                    // Fixed args are identical for every match in the group
+                    let mut final_args = fixed_args.clone();
+
+                    // Expand the ":all" arguments per match, preserving the
+                    // pairing of variables captured from the same path, and
+                    // deduplicating matches that share identical variables
+                    let mut seen = BTreeSet::new();
+                    for m in &group_matches {
+                        if seen.insert(&m.variables) {
+                            for kind in &arg_kinds {
+                                if let ArgKind::Variable { template, .. } = kind {
+                                    final_args.push(substitute(template, &m.variables));
+                                }
+                            }
+                        }
+                    }
+                    results.push(CompiledHandler(Handler::Run {
+                        run: final_run,
+                        args: final_args,
+                    }));
+                }
+                Ok(results)
             }
-            Handler::Delete { delete } => CompiledHandler(Handler::Delete { delete: delete.clone() }),
+
+            Handler::Delete { delete } => Ok(vec![CompiledHandler(Handler::Delete { delete: delete.clone() })]),
         }
     }
 }

--- a/crates/triggers/src/lib.rs
+++ b/crates/triggers/src/lib.rs
@@ -14,20 +14,23 @@ pub mod format;
 pub struct Collection<'a> {
     handlers: Vec<ExtractedHandler<'a>>,
     triggers: BTreeMap<String, &'a Trigger>,
-    hits: BTreeMap<String, BTreeSet<format::CompiledHandler>>,
+    hits: BTreeMap<String, BTreeMap<String, BTreeSet<fnmatch::Match>>>,
 }
 
 #[derive(Debug)]
 struct ExtractedHandler<'a> {
     id: &'a str,
+    handler_id: &'a str,
     pattern: &'a fnmatch::Pattern,
-    handler: &'a format::Handler,
 }
 
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("missing handler reference in {0}: {1}")]
     MissingHandler(String, String),
+
+    #[error("unknown argument variable mode {0} (expected 'each' or 'all')")]
+    UnknownArgMode(String),
 }
 
 impl<'a> Collection<'a> {
@@ -40,14 +43,14 @@ impl<'a> Collection<'a> {
             for (p, def) in trigger.paths.iter() {
                 for used_handler in def.handlers.iter() {
                     // Ensure we have a corresponding handler
-                    let handler = trigger
+                    trigger
                         .handlers
                         .get(used_handler)
                         .ok_or(Error::MissingHandler(trigger.name.clone(), used_handler.clone()))?;
                     handlers.push(ExtractedHandler {
                         id: &trigger.name,
+                        handler_id: used_handler,
                         pattern: p,
-                        handler,
                     });
                 }
             }
@@ -62,17 +65,16 @@ impl<'a> Collection<'a> {
 
     /// Process a batch set of paths and record the "hit"
     pub fn process_paths(&mut self, paths: impl Iterator<Item = String>) {
-        let results = paths.into_iter().flat_map(|p| {
-            self.handlers
-                .iter()
-                .filter_map(move |h| h.pattern.match_path(&p).map(|m| (h.id, h.handler.compiled(&m))))
-        });
-
-        for (id, handler) in results {
-            if let Some(map) = self.hits.get_mut(id) {
-                map.insert(handler);
-            } else {
-                self.hits.insert(id.into(), BTreeSet::from_iter([handler]));
+        for p in paths {
+            for h in &self.handlers {
+                if let Some(m) = h.pattern.match_path(&p) {
+                    self.hits
+                        .entry(h.id.to_owned())
+                        .or_default()
+                        .entry(h.handler_id.to_owned())
+                        .or_default()
+                        .insert(m);
+                }
             }
         }
     }
@@ -116,12 +118,24 @@ impl<'a> Collection<'a> {
             }
         }
 
-        // Recollect in dependency order
-        let results = graph
-            .topo()
-            .filter_map(|i| self.hits.remove(i))
-            .flatten()
-            .collect::<Vec<_>>();
+        let mut results = Vec::new();
+        for id in graph.topo() {
+            let Some(trigger) = self.triggers.get(id) else {
+                continue;
+            };
+            let Some(hits) = self.hits.get(id) else {
+                continue;
+            };
+
+            let mut stage_handlers = Vec::new();
+            for (handler_id, matches) in hits {
+                let Some(handler) = trigger.handlers.get(handler_id) else {
+                    continue;
+                };
+                stage_handlers.extend(handler.coalesced(matches)?);
+            }
+            results.extend(stage_handlers);
+        }
         Ok(results)
     }
 }


### PR DESCRIPTION
Currently, trigger handlers execute once per matched path, this can be slow for trigger handlerss which support processing multiple args.

Introduce argument expansion which allows triggers to batch arguments

- $(var) / $(var:each) - Execute handler per match
- $(var:all) - Execute handler against batched matches

e.g. instead of
systemctl preset foo.service
systemctl preset bar.service
systemctl preset baz.service

Do:
systemctl preset foo.service bar.service baz.service