### PR TITLE
moss: Refactor "blit" to new fstree native module

### DIFF
--- a/crates/vfs/src/lib.rs
+++ b/crates/vfs/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! VFS assistance for moss including optimised tree + blit helpers
-pub use self::tree::Tree;
+pub use self::tree::{BlitFile, Tree, builder::TreeBuilder};
 
 pub mod cache;
 pub mod path;

--- a/moss/src/cli/info.rs
+++ b/moss/src/cli/info.rs
@@ -6,7 +6,9 @@ use itertools::Itertools;
 use moss::{
     Installation, Package, Provider,
     client::{self, Client},
-    environment, package,
+    environment,
+    fstree::PendingFile,
+    package,
 };
 use stone::StonePayloadLayoutFile;
 use thiserror::Error;
@@ -165,7 +167,7 @@ fn print_package(pkg: &Package) {
     }
 }
 
-fn print_files(vfs: vfs::Tree<client::PendingFile>) {
+fn print_files(vfs: vfs::Tree<PendingFile>) {
     let files = vfs
         .iter()
         .filter_map(|file| {

--- a/moss/src/client/extract.rs
+++ b/moss/src/client/extract.rs
@@ -14,7 +14,7 @@ use tui::{ProgressBar, ProgressStyle};
 use crate::{
     Installation,
     client::{self, cache::asset_path},
-    installation,
+    fstree, installation,
     package::{self, MissingMetaFieldError},
     util,
 };
@@ -113,9 +113,9 @@ pub fn extract(stones: Vec<&PathBuf>, output_dir: &Path) -> Result<(), Error> {
             .into_iter()
             .map(|layout| (pkg_id.clone(), layout))
             .collect::<Vec<_>>();
-        let vfs = client::vfs(records)?;
+        let vfs = fstree::vfs(records).map_err(Error::BuildVfsTree)?;
 
-        client::blit_root(&installation, &vfs, &extraction_root.canonicalize()?)?;
+        fstree::native::blit_root(&installation, &vfs, &extraction_root.canonicalize()?).map_err(Error::BlitFstree)?;
     }
 
     // Clean up transient .moss install
@@ -143,4 +143,10 @@ pub enum Error {
 
     #[error("installation")]
     Installation(#[from] installation::Error),
+
+    #[error("build vfs tree")]
+    BuildVfsTree(#[source] vfs::tree::Error),
+
+    #[error("blit fstree")]
+    BlitFstree(#[source] fstree::native::Error),
 }

--- a/moss/src/client/mod.rs
+++ b/moss/src/client/mod.rs
@@ -10,34 +10,25 @@
 
 use std::{
     borrow::Borrow,
-    fmt, io,
-    os::{
-        fd::{AsRawFd, FromRawFd, RawFd},
-        unix::fs::symlink,
-    },
+    io,
+    os::unix::fs::symlink,
     path::{Path, PathBuf},
     time::{Duration, Instant},
 };
 
-use astr::AStr;
 use fs_err as fs;
 use futures_util::{StreamExt, TryStreamExt, stream};
 use itertools::Itertools;
 use nix::{
     NixPath,
     errno::Errno,
-    fcntl::{self, AtFlags, OFlag},
-    libc::{AT_FDCWD, FICLONE, RENAME_EXCHANGE, SYS_renameat2, ioctl, syscall},
-    sys::stat::{Mode, fchmod, fstat, mkdirat, umask},
-    unistd::{Gid, Uid, close, fchown, mkdir, symlinkat},
+    libc::{AT_FDCWD, RENAME_EXCHANGE, SYS_renameat2, syscall},
 };
 use postblit::TriggerScope;
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
-use stone::{StoneDecodedPayload, StonePayloadLayoutFile, StonePayloadLayoutRecord};
+use stone::{StoneDecodedPayload, StonePayloadLayoutRecord};
 use thiserror::Error;
-use tracing::{info, info_span, trace, warn};
+use tracing::{info, info_span};
 use tui::{MultiProgress, ProgressBar, ProgressStyle, Styled};
-use vfs::tree::{BlitFile, Element, builder::TreeBuilder};
 
 use self::install::install;
 use self::prune::{prune_cache, prune_states};
@@ -47,7 +38,7 @@ use self::verify::verify;
 use crate::{
     Installation, Package, Provider, Registry, Signal, State, SystemModel,
     client::fetch::fetch,
-    db, environment, installation, package,
+    db, environment, fstree, installation, package,
     registry::plugin::{self, Plugin},
     repository, runtime, signal,
     state::{self, Selection},
@@ -460,7 +451,7 @@ impl Client {
     }
 
     /// Apply all triggers with the given scope, wrapping with a progressbar.
-    fn apply_triggers(scope: TriggerScope<'_>, fstree: &vfs::Tree<PendingFile>) -> Result<(), postblit::Error> {
+    fn apply_triggers(scope: TriggerScope<'_>, fstree: &vfs::Tree<fstree::PendingFile>) -> Result<(), postblit::Error> {
         let triggers = postblit::triggers(scope, fstree)?;
 
         let progress = ProgressBar::new(triggers.len() as u64).with_style(
@@ -517,7 +508,7 @@ impl Client {
 
     pub fn apply_stateful_blit(
         &self,
-        fstree: vfs::Tree<PendingFile>,
+        fstree: vfs::Tree<fstree::PendingFile>,
         state: &State,
         old_state: Option<state::Id>,
         system_model: SystemModel,
@@ -558,7 +549,7 @@ impl Client {
 
     pub fn apply_ephemeral_blit(
         &self,
-        fstree: vfs::Tree<PendingFile>,
+        fstree: vfs::Tree<fstree::PendingFile>,
         blit_root: &Path,
         system_model: SystemModel,
     ) -> Result<(), Error> {
@@ -601,7 +592,7 @@ impl Client {
         }
 
         // Now swap staging with live
-        atomic_swap(&usr_source, &usr_target)?;
+        atomic_swap(&usr_source, &usr_target).map_err(Error::AtomicSwap)?;
 
         Ok(())
     }
@@ -799,15 +790,15 @@ impl Client {
         Ok(())
     }
 
-    /// Build a [`vfs::Tree`] for the specified package IDs
+    /// Build a [`vfs::Tree`] for the specified packages.
     ///
-    /// Returns a newly built vfs Tree to plan the filesystem operations for blitting
-    /// and conflict detection.
+    /// Returns a newly built [`vfs::Tree`] that can be used in
+    /// the creation of fstrees.
     pub fn vfs<'a>(
         &self,
         packages: impl IntoIterator<Item = &'a package::Id>,
-    ) -> Result<vfs::Tree<PendingFile>, Error> {
-        vfs(self.layout_db.query(packages)?)
+    ) -> Result<vfs::Tree<fstree::PendingFile>, Error> {
+        fstree::vfs(self.layout_db.query(packages)?).map_err(Error::BuildVfsTree)
     }
 
     /// Blit the packages to a filesystem root
@@ -825,7 +816,7 @@ impl Client {
     pub fn blit_root<'a>(
         &self,
         packages: impl IntoIterator<Item = &'a package::Id>,
-    ) -> Result<vfs::Tree<PendingFile>, Error> {
+    ) -> Result<vfs::Tree<fstree::PendingFile>, Error> {
         let blit_target = match &self.scope {
             Scope::Stateful => self.installation.staging_dir(),
             Scope::Ephemeral { blit_root } => blit_root.to_owned(),
@@ -833,7 +824,7 @@ impl Client {
 
         let fstree = self.vfs(packages)?;
 
-        blit_root(&self.installation, &fstree, &blit_target)?;
+        fstree::native::blit_root(&self.installation, &fstree, &blit_target).map_err(Error::Blit)?;
 
         Ok(fstree)
     }
@@ -969,92 +960,6 @@ fn create_root_links(root: &Path) -> io::Result<()> {
     Ok(())
 }
 
-/// Build a [`vfs::Tree`] for the specified layouts
-///
-/// Returns a newly built vfs Tree to plan the filesystem operations for blitting
-/// and conflict detection.
-pub fn vfs(layouts: Vec<(package::Id, StonePayloadLayoutRecord)>) -> Result<vfs::Tree<PendingFile>, Error> {
-    let mut tbuild = TreeBuilder::new();
-
-    for (id, layout) in layouts {
-        tbuild.push(PendingFile { id: id.clone(), layout });
-    }
-
-    tbuild.bake();
-
-    Ok(tbuild.tree()?)
-}
-
-#[derive(Debug, Clone, Copy, strum::Display)]
-#[strum(serialize_all = "lowercase")]
-enum BlitStrategy {
-    Reflink,
-    Hardlink,
-    Copy,
-}
-
-/// Attempts to find the best blit strategy in order of priority: `reflink` -> `hardlink` -> `copy`
-///
-/// `copy` is only used if `EXDEV` / `cross-device link not permitted`, otherwise
-/// any other error during this test falls back to `hardlink` to ensure we don't
-/// accidentally `copy` on unexpected errors, and to introduce regression against
-/// the previous `hardlink` only behavior
-fn identify_blit_strategy(installation: &Installation, blit_target: &Path) -> BlitStrategy {
-    let from = installation.cache_path(".link-test");
-    let to = blit_target.join(".link-test");
-
-    let identify = || -> io::Result<_> {
-        // Remove both if they already exist
-        if from.exists() {
-            fs::remove_file(&from)?;
-        }
-        if to.exists() {
-            fs::remove_file(&to)?;
-        }
-
-        // Create empty from
-        fs::write(&from, b"")?;
-
-        // Open from file
-        let source = fs::OpenOptions::new().read(true).open(&from)?;
-        // Target file should be _new_ for reflink test
-        let target = fs::OpenOptions::new().write(true).create_new(true).open(&to)?;
-
-        // Attempt reflink
-        let res = reflink(source, target);
-
-        if res.is_ok() {
-            return Ok(BlitStrategy::Reflink);
-        }
-
-        // Remove to created above so we can test hardlink
-        fs::remove_file(&to)?;
-
-        // Attempt hardlink
-        let res = linkat(None, &from, None, &to);
-
-        match res {
-            Err(Errno::EXDEV) => Ok(BlitStrategy::Copy),
-            _ => Ok(BlitStrategy::Hardlink),
-        }
-    };
-
-    // Fallback to hardlink on error
-    let strategy = identify().unwrap_or_else(|err| {
-        warn!(
-            error = format!("{err:#}"),
-            "Failed to identify blit strategy, falling back to hardlink strategy"
-        );
-        BlitStrategy::Hardlink
-    });
-
-    // Cleanup
-    let _ = fs::remove_file(&from);
-    let _ = fs::remove_file(&to);
-
-    strategy
-}
-
 /// syscall based wrapper for renameat2 so we can support musl libc which
 /// unfortunately does not expose the API.
 /// largely modelled on existing renameat2 API in nix crate
@@ -1072,385 +977,6 @@ fn atomic_swap<A: ?Sized + NixPath, B: ?Sized + NixPath>(old_path: &A, new_path:
         })
     })?? as i32;
     Errno::result(result).map(drop)
-}
-
-/// [`nix::unistd::linkat`] doesn't supply AT_EMPTY_PATH
-/// to allow `olddirfd` to be the source FD, so we override
-/// their implementation to support this usecase
-fn linkat<P: ?Sized + NixPath>(
-    olddirfd: Option<RawFd>,
-    oldpath: &P,
-    newdirfd: Option<RawFd>,
-    newpath: &P,
-) -> nix::Result<()> {
-    use nix::libc;
-
-    let atflag = if olddirfd.is_some() && oldpath.is_empty() {
-        AtFlags::AT_EMPTY_PATH
-    } else {
-        AtFlags::empty()
-    };
-    let at_rawfd = |fd: Option<RawFd>| match fd {
-        Some(fd) => fd,
-        None => AT_FDCWD,
-    };
-
-    let res = oldpath.with_nix_path(|oldcstr| {
-        newpath.with_nix_path(|newcstr| unsafe {
-            libc::linkat(
-                at_rawfd(olddirfd),
-                oldcstr.as_ptr(),
-                at_rawfd(newdirfd),
-                newcstr.as_ptr(),
-                atflag.bits(),
-            )
-        })
-    })??;
-    Errno::result(res).map(drop)
-}
-
-fn reflink(source: impl AsRawFd, target: impl AsRawFd) -> nix::Result<()> {
-    let res = unsafe { ioctl(target.as_raw_fd(), FICLONE, source.as_raw_fd()) };
-    Errno::result(res).map(drop)
-}
-
-struct BlitContext<'a> {
-    is_user_root: bool,
-    blit_strategy: BlitStrategy,
-    cache_fd: RawFd,
-    progress: &'a ProgressBar,
-}
-
-/// Blit the packages to a filesystem root
-///
-/// This functionality is core to all moss filesystem transactions, forming the entire
-/// staging logic. For all the [`crate::package::Id`] present in the staging state,
-/// query their stored [`StonePayloadLayoutBody`] and cache into a [`vfs::Tree`].
-///
-/// The new `/usr` filesystem is written in optimal order to a staging tree by making
-/// use of the "at" family of functions (`mkdirat`, `linkat`, etc) with relative directory
-/// file descriptors, linking files from the assets store to provide deduplication.
-///
-/// This provides a very quick means to generate a hardlinked "snapshot" on-demand,
-/// which can then be activated via [`Self::promote_staging`]
-pub fn blit_root(installation: &Installation, tree: &vfs::Tree<PendingFile>, blit_target: &Path) -> Result<(), Error> {
-    let is_user_root = Uid::effective().is_root();
-
-    // Recreate dir
-    let _ = fs::remove_dir_all(blit_target);
-    mkdir(blit_target, Mode::from_bits_truncate(0o755))?;
-
-    // Ensure umask is cleared so we get exact modes
-    let old_umask = umask(Mode::empty());
-
-    // Identify blit strategy based on FS in use
-    let blit_strategy = identify_blit_strategy(installation, blit_target);
-    info!(%blit_strategy, "Blit strategy identified");
-
-    let progress = ProgressBar::new(1).with_style(
-        ProgressStyle::with_template("\n|{bar:20.red/blue}| {pos}/{len} {msg}")
-            .unwrap()
-            .progress_chars("■≡=- "),
-    );
-    progress.set_message("Blitting filesystem");
-    progress.enable_steady_tick(Duration::from_millis(150));
-    progress.tick();
-
-    let now = Instant::now();
-    let mut stats = BlitStats::default();
-
-    progress.set_length(tree.len());
-    progress.set_position(0_u64);
-
-    let cache_dir = installation.assets_path("v2");
-    let cache_fd = fcntl::open(&cache_dir, OFlag::O_DIRECTORY | OFlag::O_RDONLY, Mode::empty())?;
-
-    let ctx = BlitContext {
-        is_user_root,
-        blit_strategy,
-        cache_fd,
-        progress: &progress,
-    };
-
-    // We need to ensure this runtime is dropped so it doesn't linger
-    // since this is in the boulder call path & boulder can't have
-    // multithreading when CLONE into a user namespace / "container"
-    let rayon_runtime = rayon::ThreadPoolBuilder::new().build().expect("rayon runtime");
-
-    rayon_runtime.install(|| -> Result<(), Error> {
-        if let Some(root) = tree.structured() {
-            let root_dir = fcntl::open(blit_target, OFlag::O_DIRECTORY | OFlag::O_RDONLY, Mode::empty())?;
-
-            if let Element::Directory(_, _, children) = root {
-                let current_span = tracing::Span::current();
-                stats = stats.merge(
-                    children
-                        .into_par_iter()
-                        .map(|child| {
-                            let _guard = current_span.enter();
-                            blit_element(&ctx, root_dir, child)
-                        })
-                        .try_reduce(BlitStats::default, |a, b| Ok(a.merge(b)))?,
-                );
-            }
-
-            close(root_dir)?;
-        }
-
-        Ok(())
-    })?;
-
-    // Cleanup
-    close(ctx.cache_fd)?;
-    umask(old_umask);
-    progress.finish_and_clear();
-
-    let elapsed = now.elapsed();
-    let num_entries = stats.num_entries();
-
-    println!(
-        "\n{} entries blitted in {} {}",
-        num_entries.to_string().bold(),
-        format!("{:.2}s", elapsed.as_secs_f32()).bold(),
-        format!("({:.1}k / s)", num_entries as f32 / elapsed.as_secs_f32() / 1_000.0).dim()
-    );
-
-    Ok(())
-}
-
-/// Recursively write a directory, or a single flat inode, to the staging tree.
-/// Care is taken to retain the directory file descriptor to avoid costly path
-/// resolution at runtime.
-fn blit_element(ctx: &BlitContext<'_>, parent: RawFd, element: Element<'_, PendingFile>) -> Result<BlitStats, Error> {
-    let mut stats = BlitStats::default();
-
-    ctx.progress.inc(1);
-
-    let (_, item) = match &element {
-        Element::Directory(_, item, _) => ("directory", item),
-        Element::Child(_, item) => ("file", item),
-    };
-
-    trace!(
-        progress = ctx.progress.position() as f32 / ctx.progress.length().unwrap_or(1) as f32,
-        current = ctx.progress.position() as usize,
-        total = ctx.progress.length().unwrap_or(0) as usize,
-        event_type = "progress_update",
-        "Blitting {}",
-        item.path()
-    );
-
-    match element {
-        Element::Directory(name, item, children) => {
-            // Construct within the parent
-            blit_element_item(ctx, parent, name, item, &mut stats)?;
-
-            // open the new dir
-            let newdir = fcntl::openat(parent, name, OFlag::O_RDONLY | OFlag::O_DIRECTORY, Mode::empty())?;
-
-            let current_span = tracing::Span::current();
-            stats = stats.merge(
-                children
-                    .into_par_iter()
-                    .map(|child| {
-                        let _guard = current_span.enter();
-                        blit_element(ctx, newdir, child)
-                    })
-                    .try_reduce(BlitStats::default, |a, b| Ok(a.merge(b)))?,
-            );
-
-            close(newdir)?;
-
-            Ok(stats)
-        }
-        Element::Child(name, item) => {
-            blit_element_item(ctx, parent, name, item, &mut stats)?;
-
-            Ok(stats)
-        }
-    }
-}
-
-/// Write a single inode into the staging tree.
-///
-/// # Arguments
-///
-/// * `parent`  - raw file descriptor for parent directory in which the inode is being record to
-/// * `cache`   - raw file descriptor for the system asset pool tree
-/// * `subpath` - the base name of the new inode
-/// * `item`    - New inode being recorded
-fn blit_element_item(
-    ctx: &BlitContext<'_>,
-    parent: RawFd,
-    subpath: &str,
-    item: &PendingFile,
-    stats: &mut BlitStats,
-) -> Result<(), Error> {
-    const EMPTY_FILE_HASH: u128 = 0x99aa_06d3_0147_98d8_6001_c324_468d_497f;
-
-    match &item.layout.file {
-        StonePayloadLayoutFile::Regular(id, _) => {
-            let hash = format!("{id:02x}");
-            let directory = if hash.len() >= 10 {
-                PathBuf::from(&hash[..2]).join(&hash[2..4]).join(&hash[4..6])
-            } else {
-                "".into()
-            };
-
-            // Link relative from cache to target
-            let fp = directory.join(hash);
-
-            // Strip write bit.
-            //
-            // Our blitted roots are intended for read-only, immutable use.
-            // This doesn't necessarily help enforce anything and we will
-            // leverage other strategies to enforce true immutability. But
-            // no write bit is ever needed, so may as well strip it.
-            let blit_mode = item.layout.mode & !0o222;
-
-            match *id {
-                // Mystery empty-file hash. Do not allow dupes!
-                // https://github.com/AerynOS/os-tools/issues/372
-                EMPTY_FILE_HASH => {
-                    let fd = fcntl::openat(
-                        parent,
-                        subpath,
-                        OFlag::O_CREAT | OFlag::O_WRONLY | OFlag::O_TRUNC,
-                        // We can specify mode here used to create the file.
-                        Mode::from_bits_truncate(blit_mode),
-                    )?;
-                    close(fd)?;
-                }
-                // Regular file
-                _ => {
-                    match ctx.blit_strategy {
-                        BlitStrategy::Reflink => {
-                            // Open FD to source
-                            let src = fcntl::openat(ctx.cache_fd, &fp, OFlag::O_RDONLY, Mode::empty())?;
-                            // Create new inode & get its FD.
-                            let dest = fcntl::openat(
-                                parent,
-                                subpath,
-                                OFlag::O_CREAT | OFlag::O_EXCL | OFlag::O_WRONLY,
-                                // We can specify mode here used to create the file.
-                                Mode::from_bits_truncate(blit_mode),
-                            )?;
-
-                            // Apply special bits stripped from mode during `openat`
-                            if blit_mode & 0o7000 > 0 {
-                                fchmod(dest, Mode::from_bits_truncate(blit_mode))?;
-                            }
-
-                            // Reflink from source to dest
-                            reflink(src, dest)?;
-
-                            // Update ownership if we can
-                            if ctx.is_user_root {
-                                let uid = Uid::from_raw(item.layout.uid);
-                                let gid = Gid::from_raw(item.layout.gid);
-
-                                if !(uid.is_root() || gid.as_raw() == 0) {
-                                    fchown(
-                                        dest,
-                                        Some(Uid::from_raw(item.layout.uid)),
-                                        Some(Gid::from_raw(item.layout.gid)),
-                                    )?;
-                                }
-                            }
-
-                            // Cleanup FDs
-                            close(src)?;
-                            close(dest)?;
-                        }
-                        BlitStrategy::Hardlink => {
-                            // Open FD for CAS file
-                            let src = fcntl::openat(ctx.cache_fd, &fp, OFlag::O_RDONLY, Mode::empty())?;
-                            // Get existing mode
-                            let existing_mode = fstat(src)?.st_mode;
-
-                            // Handle permissions
-                            //
-                            // Since hardlinks share inode / metadata, this is a
-                            // dangerous operation as any changes here impact ALL
-                            // links to this file and may impact the running system.
-                            // We need to ensure mode can never lose its executability
-                            // if another file needs that executability.
-                            //
-                            // We therefore combine the two (more permissive) and always
-                            // strip out the `w` bit since this should be immutable / read-only.
-                            // If that is different from the existing mode, we can safely apply it.
-                            let desired_mode = (existing_mode | blit_mode) & !0o222;
-
-                            if existing_mode != desired_mode {
-                                fchmod(src, Mode::from_bits_truncate(desired_mode))?;
-                            }
-
-                            // Create link to blit target
-                            linkat(Some(src), "", Some(parent), subpath)?;
-                        }
-                        #[allow(clippy::disallowed_types)]
-                        BlitStrategy::Copy => {
-                            // Open FD to source
-                            let src = fcntl::openat(ctx.cache_fd, &fp, OFlag::O_RDONLY, Mode::empty())?;
-                            // Create dest inode & get its FD.
-                            let dest = fcntl::openat(
-                                parent,
-                                subpath,
-                                OFlag::O_CREAT | OFlag::O_EXCL | OFlag::O_WRONLY,
-                                // We can specify mode here used to create the file.
-                                Mode::from_bits_truncate(blit_mode),
-                            )?;
-
-                            // Apply special bits stripped from mode during `openat`
-                            if blit_mode & 0o7000 > 0 {
-                                fchmod(dest, Mode::from_bits_truncate(blit_mode))?;
-                            }
-
-                            // Copy (rust uses copy_file_range where possible)
-                            //
-                            // FDs are dropped when File is dropped
-                            let mut from = unsafe { std::fs::File::from_raw_fd(src) };
-                            let mut to = unsafe { std::fs::File::from_raw_fd(dest) };
-                            io::copy(&mut from, &mut to).map_err(|_| Errno::last())?;
-
-                            // Update ownership if we can
-                            if ctx.is_user_root {
-                                let uid = Uid::from_raw(item.layout.uid);
-                                let gid = Gid::from_raw(item.layout.gid);
-
-                                if !(uid.is_root() || gid.as_raw() == 0) {
-                                    fchown(
-                                        dest,
-                                        Some(Uid::from_raw(item.layout.uid)),
-                                        Some(Gid::from_raw(item.layout.gid)),
-                                    )?;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            stats.num_files += 1;
-        }
-        StonePayloadLayoutFile::Symlink(source, _) => {
-            symlinkat(source.as_str(), Some(parent), subpath)?;
-            stats.num_symlinks += 1;
-        }
-        StonePayloadLayoutFile::Directory(_) => {
-            mkdirat(parent, subpath, Mode::from_bits_truncate(item.layout.mode))?;
-            stats.num_dirs += 1;
-        }
-
-        // Unimplemented
-        StonePayloadLayoutFile::CharacterDevice(_)
-        | StonePayloadLayoutFile::BlockDevice(_)
-        | StonePayloadLayoutFile::Fifo(_)
-        | StonePayloadLayoutFile::Socket(_)
-        | StonePayloadLayoutFile::Unknown(..) => {}
-    };
-
-    Ok(())
 }
 
 fn record_state_id(root: &Path, state: state::Id) -> Result<(), Error> {
@@ -1552,85 +1078,6 @@ impl Scope {
     }
 }
 
-/// A pending file for blitting
-#[derive(Debug, Clone)]
-pub struct PendingFile {
-    /// The origin package for this file/inode
-    pub id: package::Id,
-
-    /// Corresponding layout entry, describing the inode
-    pub layout: StonePayloadLayoutRecord,
-}
-
-impl BlitFile for PendingFile {
-    /// Match internal kind to minimalist vfs kind
-    fn kind(&self) -> vfs::tree::Kind {
-        match &self.layout.file {
-            StonePayloadLayoutFile::Symlink(source, _) => vfs::tree::Kind::Symlink(source.clone()),
-            StonePayloadLayoutFile::Directory(_) => vfs::tree::Kind::Directory,
-            _ => vfs::tree::Kind::Regular,
-        }
-    }
-
-    /// Return ID for conflict
-    fn id(&self) -> AStr {
-        self.id.clone().into()
-    }
-
-    /// Resolve the target path, including the missing `/usr` prefix
-    fn path(&self) -> AStr {
-        let result = match &self.layout.file {
-            StonePayloadLayoutFile::Regular(_, target) => target.clone(),
-            StonePayloadLayoutFile::Symlink(_, target) => target.clone(),
-            StonePayloadLayoutFile::Directory(target) => target.clone(),
-            StonePayloadLayoutFile::CharacterDevice(target) => target.clone(),
-            StonePayloadLayoutFile::BlockDevice(target) => target.clone(),
-            StonePayloadLayoutFile::Fifo(target) => target.clone(),
-            StonePayloadLayoutFile::Socket(target) => target.clone(),
-            StonePayloadLayoutFile::Unknown(.., target) => target.clone(),
-        };
-
-        vfs::path::join("/usr", &result)
-    }
-
-    /// Clone the node to a reparented path, for symlink resolution
-    fn cloned_to(&self, path: AStr) -> Self {
-        let mut new = self.clone();
-        new.layout.file = match &self.layout.file {
-            StonePayloadLayoutFile::Regular(source, _) => StonePayloadLayoutFile::Regular(*source, path),
-            StonePayloadLayoutFile::Symlink(source, _) => StonePayloadLayoutFile::Symlink(source.clone(), path),
-            StonePayloadLayoutFile::Directory(_) => StonePayloadLayoutFile::Directory(path),
-            StonePayloadLayoutFile::CharacterDevice(_) => StonePayloadLayoutFile::CharacterDevice(path),
-            StonePayloadLayoutFile::BlockDevice(_) => StonePayloadLayoutFile::BlockDevice(path),
-            StonePayloadLayoutFile::Fifo(_) => StonePayloadLayoutFile::Fifo(path),
-            StonePayloadLayoutFile::Socket(_) => StonePayloadLayoutFile::Socket(path),
-            StonePayloadLayoutFile::Unknown(source, _) => StonePayloadLayoutFile::Unknown(source.clone(), path),
-        };
-        new
-    }
-}
-
-impl From<AStr> for PendingFile {
-    fn from(value: AStr) -> Self {
-        PendingFile {
-            id: Default::default(),
-            layout: StonePayloadLayoutRecord {
-                uid: 0,
-                gid: 0,
-                mode: 0o755,
-                tag: 0,
-                file: StonePayloadLayoutFile::Directory(value),
-            },
-        }
-    }
-}
-
-impl fmt::Display for PendingFile {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.path().fmt(f)
-    }
-}
-
 /// Build a [`crate::registry::Registry`] during client initialisation
 ///
 /// # Arguments
@@ -1660,27 +1107,6 @@ fn build_registry(
     }
 
     Ok(registry)
-}
-
-#[derive(Debug, Clone, Copy, Default)]
-struct BlitStats {
-    num_files: u64,
-    num_symlinks: u64,
-    num_dirs: u64,
-}
-
-impl BlitStats {
-    fn merge(self, other: Self) -> Self {
-        Self {
-            num_files: self.num_files + other.num_files,
-            num_symlinks: self.num_symlinks + other.num_symlinks,
-            num_dirs: self.num_dirs + other.num_dirs,
-        }
-    }
-
-    fn num_entries(&self) -> u64 {
-        self.num_files + self.num_symlinks + self.num_dirs
-    }
 }
 
 /// Client-relevant error mapping type
@@ -1715,7 +1141,7 @@ pub enum Error {
     #[error("filesystem")]
     Filesystem(#[from] vfs::tree::Error),
     #[error("blit")]
-    Blit(#[from] Errno),
+    Blit(#[source] fstree::native::Error),
     #[error("postblit")]
     PostBlit(#[from] postblit::Error),
     #[error("boot")]
@@ -1742,4 +1168,8 @@ pub enum Error {
     Sync(#[source] Box<sync::Error>),
     #[error("system model doesn't exist at {0:?}")]
     ImportSystemModelDoesntExist(PathBuf),
+    #[error("build vfs tree")]
+    BuildVfsTree(#[source] vfs::tree::Error),
+    #[error("atomic swap")]
+    AtomicSwap(#[source] Errno),
 }

--- a/moss/src/client/postblit.rs
+++ b/moss/src/client/postblit.rs
@@ -12,7 +12,6 @@ use std::{
     process,
 };
 
-use crate::Installation;
 use container::Container;
 use itertools::Itertools;
 use serde::Deserialize;
@@ -20,7 +19,7 @@ use thiserror::Error;
 use tracing::{error, warn};
 use triggers::format::{CompiledHandler, Handler, Trigger};
 
-use super::PendingFile;
+use crate::{Installation, fstree::PendingFile};
 
 /// Transaction trigger wrapper
 /// These are loaded from `/usr/share/moss/triggers/tx.d/*.yaml`

--- a/moss/src/fstree.rs
+++ b/moss/src/fstree.rs
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2026 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
+//! Drivers for creating portable filesystem trees (`fstree`) from _virtual_
+//! fstrees ([`vfs::Tree`]) and their backing content (`CAS` / content address store).
+
+use std::fmt;
+
+use astr::AStr;
+use stone::{StonePayloadLayoutFile, StonePayloadLayoutRecord};
+
+use crate::package;
+
+pub mod native;
+
+/// A file pending creation to an `fstree`
+#[derive(Debug, Clone)]
+pub struct PendingFile {
+    /// The origin package for this file/inode
+    pub id: package::Id,
+
+    /// Corresponding layout entry, describing the inode
+    pub layout: StonePayloadLayoutRecord,
+}
+
+impl vfs::BlitFile for PendingFile {
+    /// Match internal kind to minimalist vfs kind
+    fn kind(&self) -> vfs::tree::Kind {
+        match &self.layout.file {
+            StonePayloadLayoutFile::Symlink(source, _) => vfs::tree::Kind::Symlink(source.clone()),
+            StonePayloadLayoutFile::Directory(_) => vfs::tree::Kind::Directory,
+            _ => vfs::tree::Kind::Regular,
+        }
+    }
+
+    /// Return ID for conflict
+    fn id(&self) -> AStr {
+        self.id.clone().into()
+    }
+
+    /// Resolve the target path, including the missing `/usr` prefix
+    fn path(&self) -> AStr {
+        let result = match &self.layout.file {
+            StonePayloadLayoutFile::Regular(_, target) => target.clone(),
+            StonePayloadLayoutFile::Symlink(_, target) => target.clone(),
+            StonePayloadLayoutFile::Directory(target) => target.clone(),
+            StonePayloadLayoutFile::CharacterDevice(target) => target.clone(),
+            StonePayloadLayoutFile::BlockDevice(target) => target.clone(),
+            StonePayloadLayoutFile::Fifo(target) => target.clone(),
+            StonePayloadLayoutFile::Socket(target) => target.clone(),
+            StonePayloadLayoutFile::Unknown(.., target) => target.clone(),
+        };
+
+        vfs::path::join("/usr", &result)
+    }
+
+    /// Clone the node to a reparented path, for symlink resolution
+    fn cloned_to(&self, path: AStr) -> Self {
+        let mut new = self.clone();
+        new.layout.file = match &self.layout.file {
+            StonePayloadLayoutFile::Regular(source, _) => StonePayloadLayoutFile::Regular(*source, path),
+            StonePayloadLayoutFile::Symlink(source, _) => StonePayloadLayoutFile::Symlink(source.clone(), path),
+            StonePayloadLayoutFile::Directory(_) => StonePayloadLayoutFile::Directory(path),
+            StonePayloadLayoutFile::CharacterDevice(_) => StonePayloadLayoutFile::CharacterDevice(path),
+            StonePayloadLayoutFile::BlockDevice(_) => StonePayloadLayoutFile::BlockDevice(path),
+            StonePayloadLayoutFile::Fifo(_) => StonePayloadLayoutFile::Fifo(path),
+            StonePayloadLayoutFile::Socket(_) => StonePayloadLayoutFile::Socket(path),
+            StonePayloadLayoutFile::Unknown(source, _) => StonePayloadLayoutFile::Unknown(source.clone(), path),
+        };
+        new
+    }
+}
+
+impl From<AStr> for PendingFile {
+    fn from(value: AStr) -> Self {
+        PendingFile {
+            id: Default::default(),
+            layout: StonePayloadLayoutRecord {
+                uid: 0,
+                gid: 0,
+                mode: 0o755,
+                tag: 0,
+                file: StonePayloadLayoutFile::Directory(value),
+            },
+        }
+    }
+}
+
+impl fmt::Display for PendingFile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <Self as vfs::BlitFile>::path(self).fmt(f)
+    }
+}
+
+/// Build a [`vfs::Tree`] for the specified layouts.
+///
+/// Returns a newly built [`vfs::Tree`] that can be used in
+/// the creation of fstrees.
+pub fn vfs(layouts: Vec<(package::Id, StonePayloadLayoutRecord)>) -> Result<vfs::Tree<PendingFile>, vfs::tree::Error> {
+    let mut tbuild = vfs::TreeBuilder::new();
+
+    for (id, layout) in layouts {
+        tbuild.push(PendingFile { id: id.clone(), layout });
+    }
+
+    tbuild.bake();
+    tbuild.tree()
+}

--- a/moss/src/fstree/native.rs
+++ b/moss/src/fstree/native.rs
@@ -1,0 +1,506 @@
+// SPDX-FileCopyrightText: 2026 AerynOS Developers
+// SPDX-License-Identifier: MPL-2.0
+
+use std::{
+    io,
+    os::fd::{AsRawFd, FromRawFd, RawFd},
+    path::{Path, PathBuf},
+    time::{Duration, Instant},
+};
+
+use fs_err as fs;
+use nix::{
+    NixPath,
+    errno::Errno,
+    fcntl::{self, AtFlags, OFlag},
+    libc::{AT_FDCWD, FICLONE, ioctl},
+    sys::stat::{Mode, fchmod, fstat, mkdirat, umask},
+    unistd::{Gid, Uid, close, fchown, mkdir, symlinkat},
+};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use stone::StonePayloadLayoutFile;
+use thiserror::Error;
+use tracing::{info, trace, warn};
+use tui::{ProgressBar, ProgressStyle, Styled};
+use vfs::tree::{BlitFile, Element};
+
+use crate::Installation;
+
+use super::PendingFile;
+
+struct BlitContext<'a> {
+    is_user_root: bool,
+    blit_strategy: BlitStrategy,
+    cache_fd: RawFd,
+    progress: &'a ProgressBar,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct BlitStats {
+    num_files: u64,
+    num_symlinks: u64,
+    num_dirs: u64,
+}
+
+impl BlitStats {
+    fn merge(self, other: Self) -> Self {
+        Self {
+            num_files: self.num_files + other.num_files,
+            num_symlinks: self.num_symlinks + other.num_symlinks,
+            num_dirs: self.num_dirs + other.num_dirs,
+        }
+    }
+
+    fn num_entries(&self) -> u64 {
+        self.num_files + self.num_symlinks + self.num_dirs
+    }
+}
+
+#[derive(Debug, Clone, Copy, strum::Display)]
+#[strum(serialize_all = "lowercase")]
+enum BlitStrategy {
+    Reflink,
+    Hardlink,
+    Copy,
+}
+
+/// Attempts to find the best blit strategy in order of priority: `reflink` -> `hardlink` -> `copy`
+///
+/// `copy` is only used if `EXDEV` / `cross-device link not permitted`, otherwise
+/// any other error during this test falls back to `hardlink` to ensure we don't
+/// accidentally `copy` on unexpected errors, and to introduce regression against
+/// the previous `hardlink` only behavior
+fn identify_blit_strategy(installation: &Installation, blit_target: &Path) -> BlitStrategy {
+    let from = installation.cache_path(".link-test");
+    let to = blit_target.join(".link-test");
+
+    let identify = || -> io::Result<_> {
+        // Remove both if they already exist
+        if from.exists() {
+            fs::remove_file(&from)?;
+        }
+        if to.exists() {
+            fs::remove_file(&to)?;
+        }
+
+        // Create empty from
+        fs::write(&from, b"")?;
+
+        // Open from file
+        let source = fs::OpenOptions::new().read(true).open(&from)?;
+        // Target file should be _new_ for reflink test
+        let target = fs::OpenOptions::new().write(true).create_new(true).open(&to)?;
+
+        // Attempt reflink
+        let res = reflink(source, target);
+
+        if res.is_ok() {
+            return Ok(BlitStrategy::Reflink);
+        }
+
+        // Remove to created above so we can test hardlink
+        fs::remove_file(&to)?;
+
+        // Attempt hardlink
+        let res = linkat(None, &from, None, &to);
+
+        match res {
+            Err(Errno::EXDEV) => Ok(BlitStrategy::Copy),
+            _ => Ok(BlitStrategy::Hardlink),
+        }
+    };
+
+    // Fallback to hardlink on error
+    let strategy = identify().unwrap_or_else(|err| {
+        warn!(
+            error = format!("{err:#}"),
+            "Failed to identify blit strategy, falling back to hardlink strategy"
+        );
+        BlitStrategy::Hardlink
+    });
+
+    // Cleanup
+    let _ = fs::remove_file(&from);
+    let _ = fs::remove_file(&to);
+
+    strategy
+}
+
+/// Blit the packages to a filesystem root
+///
+/// This functionality is core to all moss filesystem transactions, forming the entire
+/// staging logic. For all the [`crate::package::Id`] present in the staging state,
+/// query their stored [`StonePayloadLayoutBody`] and cache into a [`vfs::Tree`].
+///
+/// The new `/usr` filesystem is written in optimal order to a staging tree by making
+/// use of the "at" family of functions (`mkdirat`, `linkat`, etc) with relative directory
+/// file descriptors, linking files from the assets store to provide deduplication.
+///
+/// This provides a very quick means to generate a hardlinked "snapshot" on-demand,
+/// which can then be activated via [`Self::promote_staging`]
+pub fn blit_root(installation: &Installation, tree: &vfs::Tree<PendingFile>, blit_target: &Path) -> Result<(), Error> {
+    let is_user_root = Uid::effective().is_root();
+
+    // Recreate dir
+    let _ = fs::remove_dir_all(blit_target);
+    mkdir(blit_target, Mode::from_bits_truncate(0o755))?;
+
+    // Ensure umask is cleared so we get exact modes
+    let old_umask = umask(Mode::empty());
+
+    // Identify blit strategy based on FS in use
+    let blit_strategy = identify_blit_strategy(installation, blit_target);
+    info!(%blit_strategy, "Blit strategy identified");
+
+    let progress = ProgressBar::new(1).with_style(
+        ProgressStyle::with_template("\n|{bar:20.red/blue}| {pos}/{len} {msg}")
+            .unwrap()
+            .progress_chars("■≡=- "),
+    );
+    progress.set_message("Blitting filesystem");
+    progress.enable_steady_tick(Duration::from_millis(150));
+    progress.tick();
+
+    let now = Instant::now();
+    let mut stats = BlitStats::default();
+
+    progress.set_length(tree.len());
+    progress.set_position(0_u64);
+
+    let cache_dir = installation.assets_path("v2");
+    let cache_fd = fcntl::open(&cache_dir, OFlag::O_DIRECTORY | OFlag::O_RDONLY, Mode::empty())?;
+
+    let ctx = BlitContext {
+        is_user_root,
+        blit_strategy,
+        cache_fd,
+        progress: &progress,
+    };
+
+    // We need to ensure this runtime is dropped so it doesn't linger
+    // since this is in the boulder call path & boulder can't have
+    // multithreading when CLONE into a user namespace / "container"
+    let rayon_runtime = rayon::ThreadPoolBuilder::new().build().expect("rayon runtime");
+
+    rayon_runtime.install(|| -> Result<(), Error> {
+        if let Some(root) = tree.structured() {
+            let root_dir = fcntl::open(blit_target, OFlag::O_DIRECTORY | OFlag::O_RDONLY, Mode::empty())?;
+
+            if let Element::Directory(_, _, children) = root {
+                let current_span = tracing::Span::current();
+                stats = stats.merge(
+                    children
+                        .into_par_iter()
+                        .map(|child| {
+                            let _guard = current_span.enter();
+                            blit_element(&ctx, root_dir, child)
+                        })
+                        .try_reduce(BlitStats::default, |a, b| Ok(a.merge(b)))?,
+                );
+            }
+
+            close(root_dir)?;
+        }
+
+        Ok(())
+    })?;
+
+    // Cleanup
+    close(ctx.cache_fd)?;
+    umask(old_umask);
+    progress.finish_and_clear();
+
+    let elapsed = now.elapsed();
+    let num_entries = stats.num_entries();
+
+    println!(
+        "\n{} entries blitted in {} {}",
+        num_entries.to_string().bold(),
+        format!("{:.2}s", elapsed.as_secs_f32()).bold(),
+        format!("({:.1}k / s)", num_entries as f32 / elapsed.as_secs_f32() / 1_000.0).dim()
+    );
+
+    Ok(())
+}
+
+/// Recursively write a directory, or a single flat inode, to the staging tree.
+/// Care is taken to retain the directory file descriptor to avoid costly path
+/// resolution at runtime.
+fn blit_element(ctx: &BlitContext<'_>, parent: RawFd, element: Element<'_, PendingFile>) -> Result<BlitStats, Error> {
+    let mut stats = BlitStats::default();
+
+    ctx.progress.inc(1);
+
+    let (_, item) = match &element {
+        Element::Directory(_, item, _) => ("directory", item),
+        Element::Child(_, item) => ("file", item),
+    };
+
+    trace!(
+        progress = ctx.progress.position() as f32 / ctx.progress.length().unwrap_or(1) as f32,
+        current = ctx.progress.position() as usize,
+        total = ctx.progress.length().unwrap_or(0) as usize,
+        event_type = "progress_update",
+        "Blitting {}",
+        item.path()
+    );
+
+    match element {
+        Element::Directory(name, item, children) => {
+            // Construct within the parent
+            blit_element_item(ctx, parent, name, item, &mut stats)?;
+
+            // open the new dir
+            let newdir = fcntl::openat(parent, name, OFlag::O_RDONLY | OFlag::O_DIRECTORY, Mode::empty())?;
+
+            let current_span = tracing::Span::current();
+            stats = stats.merge(
+                children
+                    .into_par_iter()
+                    .map(|child| {
+                        let _guard = current_span.enter();
+                        blit_element(ctx, newdir, child)
+                    })
+                    .try_reduce(BlitStats::default, |a, b| Ok(a.merge(b)))?,
+            );
+
+            close(newdir)?;
+
+            Ok(stats)
+        }
+        Element::Child(name, item) => {
+            blit_element_item(ctx, parent, name, item, &mut stats)?;
+
+            Ok(stats)
+        }
+    }
+}
+
+/// Write a single inode into the staging tree.
+///
+/// # Arguments
+///
+/// * `parent`  - raw file descriptor for parent directory in which the inode is being record to
+/// * `cache`   - raw file descriptor for the system asset pool tree
+/// * `subpath` - the base name of the new inode
+/// * `item`    - New inode being recorded
+fn blit_element_item(
+    ctx: &BlitContext<'_>,
+    parent: RawFd,
+    subpath: &str,
+    item: &PendingFile,
+    stats: &mut BlitStats,
+) -> Result<(), Error> {
+    const EMPTY_FILE_HASH: u128 = 0x99aa_06d3_0147_98d8_6001_c324_468d_497f;
+
+    match &item.layout.file {
+        StonePayloadLayoutFile::Regular(id, _) => {
+            let hash = format!("{id:02x}");
+            let directory = if hash.len() >= 10 {
+                PathBuf::from(&hash[..2]).join(&hash[2..4]).join(&hash[4..6])
+            } else {
+                "".into()
+            };
+
+            // Link relative from cache to target
+            let fp = directory.join(hash);
+
+            // Strip write bit.
+            //
+            // Our blitted roots are intended for read-only, immutable use.
+            // This doesn't necessarily help enforce anything and we will
+            // leverage other strategies to enforce true immutability. But
+            // no write bit is ever needed, so may as well strip it.
+            let blit_mode = item.layout.mode & !0o222;
+
+            match *id {
+                // Mystery empty-file hash. Do not allow dupes!
+                // https://github.com/AerynOS/os-tools/issues/372
+                EMPTY_FILE_HASH => {
+                    let fd = fcntl::openat(
+                        parent,
+                        subpath,
+                        OFlag::O_CREAT | OFlag::O_WRONLY | OFlag::O_TRUNC,
+                        // We can specify mode here used to create the file.
+                        Mode::from_bits_truncate(blit_mode),
+                    )?;
+                    close(fd)?;
+                }
+                // Regular file
+                _ => {
+                    match ctx.blit_strategy {
+                        BlitStrategy::Reflink => {
+                            // Open FD to source
+                            let src = fcntl::openat(ctx.cache_fd, &fp, OFlag::O_RDONLY, Mode::empty())?;
+                            // Create new inode & get its FD.
+                            let dest = fcntl::openat(
+                                parent,
+                                subpath,
+                                OFlag::O_CREAT | OFlag::O_EXCL | OFlag::O_WRONLY,
+                                // We can specify mode here used to create the file.
+                                Mode::from_bits_truncate(blit_mode),
+                            )?;
+
+                            // Apply special bits stripped from mode during `openat`
+                            if blit_mode & 0o7000 > 0 {
+                                fchmod(dest, Mode::from_bits_truncate(blit_mode))?;
+                            }
+
+                            // Reflink from source to dest
+                            reflink(src, dest)?;
+
+                            // Update ownership if we can
+                            if ctx.is_user_root {
+                                let uid = Uid::from_raw(item.layout.uid);
+                                let gid = Gid::from_raw(item.layout.gid);
+
+                                if !(uid.is_root() || gid.as_raw() == 0) {
+                                    fchown(
+                                        dest,
+                                        Some(Uid::from_raw(item.layout.uid)),
+                                        Some(Gid::from_raw(item.layout.gid)),
+                                    )?;
+                                }
+                            }
+
+                            // Cleanup FDs
+                            close(src)?;
+                            close(dest)?;
+                        }
+                        BlitStrategy::Hardlink => {
+                            // Open FD for CAS file
+                            let src = fcntl::openat(ctx.cache_fd, &fp, OFlag::O_RDONLY, Mode::empty())?;
+                            // Get existing mode
+                            let existing_mode = fstat(src)?.st_mode;
+
+                            // Handle permissions
+                            //
+                            // Since hardlinks share inode / metadata, this is a
+                            // dangerous operation as any changes here impact ALL
+                            // links to this file and may impact the running system.
+                            // We need to ensure mode can never lose its executability
+                            // if another file needs that executability.
+                            //
+                            // We therefore combine the two (more permissive) and always
+                            // strip out the `w` bit since this should be immutable / read-only.
+                            // If that is different from the existing mode, we can safely apply it.
+                            let desired_mode = (existing_mode | blit_mode) & !0o222;
+
+                            if existing_mode != desired_mode {
+                                fchmod(src, Mode::from_bits_truncate(desired_mode))?;
+                            }
+
+                            // Create link to blit target
+                            linkat(Some(src), "", Some(parent), subpath)?;
+                        }
+                        #[allow(clippy::disallowed_types)]
+                        BlitStrategy::Copy => {
+                            // Open FD to source
+                            let src = fcntl::openat(ctx.cache_fd, &fp, OFlag::O_RDONLY, Mode::empty())?;
+                            // Create dest inode & get its FD.
+                            let dest = fcntl::openat(
+                                parent,
+                                subpath,
+                                OFlag::O_CREAT | OFlag::O_EXCL | OFlag::O_WRONLY,
+                                // We can specify mode here used to create the file.
+                                Mode::from_bits_truncate(blit_mode),
+                            )?;
+
+                            // Apply special bits stripped from mode during `openat`
+                            if blit_mode & 0o7000 > 0 {
+                                fchmod(dest, Mode::from_bits_truncate(blit_mode))?;
+                            }
+
+                            // Copy (rust uses copy_file_range where possible)
+                            //
+                            // FDs are dropped when File is dropped
+                            let mut from = unsafe { std::fs::File::from_raw_fd(src) };
+                            let mut to = unsafe { std::fs::File::from_raw_fd(dest) };
+                            io::copy(&mut from, &mut to).map_err(|_| Errno::last())?;
+
+                            // Update ownership if we can
+                            if ctx.is_user_root {
+                                let uid = Uid::from_raw(item.layout.uid);
+                                let gid = Gid::from_raw(item.layout.gid);
+
+                                if !(uid.is_root() || gid.as_raw() == 0) {
+                                    fchown(
+                                        dest,
+                                        Some(Uid::from_raw(item.layout.uid)),
+                                        Some(Gid::from_raw(item.layout.gid)),
+                                    )?;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            stats.num_files += 1;
+        }
+        StonePayloadLayoutFile::Symlink(source, _) => {
+            symlinkat(source.as_str(), Some(parent), subpath)?;
+            stats.num_symlinks += 1;
+        }
+        StonePayloadLayoutFile::Directory(_) => {
+            mkdirat(parent, subpath, Mode::from_bits_truncate(item.layout.mode))?;
+            stats.num_dirs += 1;
+        }
+
+        // Unimplemented
+        StonePayloadLayoutFile::CharacterDevice(_)
+        | StonePayloadLayoutFile::BlockDevice(_)
+        | StonePayloadLayoutFile::Fifo(_)
+        | StonePayloadLayoutFile::Socket(_)
+        | StonePayloadLayoutFile::Unknown(..) => {}
+    };
+
+    Ok(())
+}
+
+/// [`nix::unistd::linkat`] doesn't supply AT_EMPTY_PATH
+/// to allow `olddirfd` to be the source FD, so we override
+/// their implementation to support this usecase
+fn linkat<P: ?Sized + NixPath>(
+    olddirfd: Option<RawFd>,
+    oldpath: &P,
+    newdirfd: Option<RawFd>,
+    newpath: &P,
+) -> nix::Result<()> {
+    use nix::libc;
+
+    let atflag = if olddirfd.is_some() && oldpath.is_empty() {
+        AtFlags::AT_EMPTY_PATH
+    } else {
+        AtFlags::empty()
+    };
+    let at_rawfd = |fd: Option<RawFd>| match fd {
+        Some(fd) => fd,
+        None => AT_FDCWD,
+    };
+
+    let res = oldpath.with_nix_path(|oldcstr| {
+        newpath.with_nix_path(|newcstr| unsafe {
+            libc::linkat(
+                at_rawfd(olddirfd),
+                oldcstr.as_ptr(),
+                at_rawfd(newdirfd),
+                newcstr.as_ptr(),
+                atflag.bits(),
+            )
+        })
+    })??;
+    Errno::result(res).map(drop)
+}
+
+fn reflink(source: impl AsRawFd, target: impl AsRawFd) -> nix::Result<()> {
+    let res = unsafe { ioctl(target.as_raw_fd(), FICLONE, source.as_raw_fd()) };
+    Errno::result(res).map(drop)
+}
+
+#[derive(Debug, Error)]
+pub enum Error {
+    // TODO: actual errors!!
+    #[error("blit")]
+    Blit(#[from] Errno),
+}

--- a/moss/src/lib.rs
+++ b/moss/src/lib.rs
@@ -15,6 +15,7 @@ pub mod client;
 pub mod db;
 pub mod dependency;
 pub mod environment;
+pub mod fstree;
 pub mod installation;
 pub mod package;
 pub mod registry;


### PR DESCRIPTION
This is a precursor for supporting multiple different fstree formats / drivers, such as the in research
overlayimg format.

This doesn't yet add any Driver trait / API, that'll come once we have the alternative implementation.

For now, this just refactors existing blit code out of `client` into `fstree::native`, there should be 0 change in the actual code.