### PR TITLE
Task/more native blit updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ nix = { version = "0.27.1", features = [
     "process",
     "mount",
     "hostname",
+    "resource",
     "signal",
     "term",
 ] }

--- a/moss/src/fstree/native.rs
+++ b/moss/src/fstree/native.rs
@@ -20,7 +20,7 @@ use nix::{
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use stone::StonePayloadLayoutFile;
 use thiserror::Error;
-use tracing::{info, trace, warn};
+use tracing::{debug, info, trace, warn};
 use tui::{ProgressBar, ProgressStyle, Styled};
 use vfs::tree::{BlitFile, Element};
 
@@ -137,6 +137,29 @@ fn identify_blit_strategy(installation: &Installation, blit_target: &Path) -> Bl
     strategy
 }
 
+/// Queries the current hard limit for number of open files
+/// and sets it as the soft limit.
+fn set_nofile_ulimit_soft_to_hard() {
+    use nix::sys::resource::{Resource, getrlimit, setrlimit};
+
+    let (soft_limit, hard_limit) = match getrlimit(Resource::RLIMIT_NOFILE) {
+        Ok(limits) => limits,
+        Err(error) => {
+            warn!(%error,"Failed to call getrlimit(nofile)");
+            return;
+        }
+    };
+
+    debug!(%soft_limit, %hard_limit, "Queried current process nofile limits");
+
+    if let Err(error) = setrlimit(Resource::RLIMIT_NOFILE, hard_limit, hard_limit) {
+        warn!(%error, "Failed to call setrlimit(nofile, {hard_limit}, {hard_limit})");
+        return;
+    }
+
+    info!(%hard_limit, "Updated current process nofile soft limit to hard limit");
+}
+
 /// Blit the packages to a filesystem root
 ///
 /// This functionality is core to all moss filesystem transactions, forming the entire
@@ -150,6 +173,11 @@ fn identify_blit_strategy(installation: &Installation, blit_target: &Path) -> Bl
 /// This provides a very quick means to generate a hardlinked "snapshot" on-demand,
 /// which can then be activated via [`Self::promote_staging`]
 pub fn blit_root(installation: &Installation, tree: &vfs::Tree<PendingFile>, blit_target: &Path) -> Result<(), Error> {
+    // Up the process nofile soft limit to be equal
+    // to the allowed hard limit to minimize the risk
+    // of EMFILE during blit
+    set_nofile_ulimit_soft_to_hard();
+
     let is_user_root = Uid::effective().is_root();
 
     // Recreate dir

--- a/moss/src/fstree/native.rs
+++ b/moss/src/fstree/native.rs
@@ -392,6 +392,9 @@ fn blit_element_item(
 
                             // Create link to blit target
                             linkat(Some(src), "", Some(parent), subpath)?;
+
+                            // Cleanup FD
+                            close(src)?;
                         }
                         #[allow(clippy::disallowed_types)]
                         BlitStrategy::Copy => {

--- a/moss/src/fstree/native.rs
+++ b/moss/src/fstree/native.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{
-    io,
+    env, io,
     os::fd::{AsRawFd, FromRawFd, RawFd},
     path::{Path, PathBuf},
     time::{Duration, Instant},
@@ -56,7 +56,7 @@ impl BlitStats {
     }
 }
 
-#[derive(Debug, Clone, Copy, strum::Display)]
+#[derive(Debug, Clone, Copy, strum::Display, strum::EnumString)]
 #[strum(serialize_all = "lowercase")]
 enum BlitStrategy {
     Reflink,
@@ -70,7 +70,18 @@ enum BlitStrategy {
 /// any other error during this test falls back to `hardlink` to ensure we don't
 /// accidentally `copy` on unexpected errors, and to introduce regression against
 /// the previous `hardlink` only behavior
+///
+/// If `MOSS_FSTREE_NATIVE_STRATEGY` env var is set, that is used instead of the
+/// above identification logic.
 fn identify_blit_strategy(installation: &Installation, blit_target: &Path) -> BlitStrategy {
+    // Allow overriding via env var
+    if let Some(strategy) = env::var("MOSS_FSTREE_NATIVE_STRATEGY")
+        .ok()
+        .and_then(|s| s.parse::<BlitStrategy>().ok())
+    {
+        return strategy;
+    }
+
     let from = installation.cache_path(".link-test");
     let to = blit_target.join(".link-test");
 


### PR DESCRIPTION
I found a regression on our hardlink strategy where I left an FD open per item blit :skull: 

I also added the ability to force a blit strategy via `MOSS_FSTREE_NATIVE_STRATEGY` var and per discussions w/ @**ermo | Rune Morling** , ensure we up the processes nofile soft limit to equal its hard limit. This will bump it from `1024` to `524288` on aeryn install.

I profiled the max open FDs on my live system blit (after fixing leaky FD) with all 3 strategies and got the following:

- `reflink` = 224396 entries blitted in 1.38s (163.2k / s) w/ max fds (164)
- `hardlink` = 224396 entries blitted in 0.95s (236.7k / s) w/ max fds (138)
- `copy` = 224398 entries blitted in 1.49s (150.7k / s) w/ max fds (146)

So only `164` FDs open at once on a fairly large install and I didn't notice big changes when adding / removing some large packages so I feel theres probably some natural backpressure keeping this in check
