### PR TITLE
rust-toolchain.yaml: Add rust-analyzer to components

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,4 +3,4 @@
 
 [toolchain]
 channel = "1.91"
-components = ["rustfmt", "clippy"]
+components = ["rust-analyzer", "rustfmt", "clippy"]


### PR DESCRIPTION
Ensures a compatible rust-analyzer is used