### PR TITLE
moss: Update blsforme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,11 +261,12 @@ dependencies = [
 [[package]]
 name = "blsforme"
 version = "0.1.0"
-source = "git+https://github.com/AerynOS/blsforme.git?rev=680720545303e123e47e0df07a8a85178c9f5c19#680720545303e123e47e0df07a8a85178c9f5c19"
+source = "git+https://github.com/AerynOS/blsforme.git?rev=55da60a60b6f883818fbd67c67557439787f2fce#55da60a60b6f883818fbd67c67557439787f2fce"
 dependencies = [
  "blake3",
  "fs-err",
  "gpt",
+ "itertools 0.15.0",
  "log",
  "nix 0.31.2",
  "os-info",
@@ -1472,7 +1473,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -1695,6 +1696,15 @@ name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -3394,7 +3404,7 @@ dependencies = [
 [[package]]
 name = "topology"
 version = "0.1.0"
-source = "git+https://github.com/AerynOS/blsforme.git?rev=680720545303e123e47e0df07a8a85178c9f5c19#680720545303e123e47e0df07a8a85178c9f5c19"
+source = "git+https://github.com/AerynOS/blsforme.git?rev=55da60a60b6f883818fbd67c67557439787f2fce#55da60a60b6f883818fbd67c67557439787f2fce"
 dependencies = [
  "fs-err",
  "gpt",
@@ -3906,7 +3916,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -3918,7 +3928,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -3935,25 +3945,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
 name = "windows-future"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -3998,7 +3995,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.94"
 
 [workspace.dependencies]
 astr.path = "crates/astr"
-blsforme = { git = "https://github.com/AerynOS/blsforme.git", rev = "680720545303e123e47e0df07a8a85178c9f5c19" }
+blsforme = { git = "https://github.com/AerynOS/blsforme.git", rev = "55da60a60b6f883818fbd67c67557439787f2fce" }
 bytes = "1.6.0"
 camino = "1.1.10"
 chrono = "0.4.38"

--- a/moss/src/client/boot.rs
+++ b/moss/src/client/boot.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use blsforme::{
-    CmdlineEntry, Entry, Schema,
+    Entry, Schema,
     bootloader::systemd_boot,
     os_release::{self, OsRelease},
 };
@@ -137,6 +137,7 @@ fn states_except_new(client: &Client, state: &State) -> Result<Vec<State>, db::E
         .sorted_by_key(|(_, whence)| whence.to_owned())
         .rev()
         .take(4)
+        .rev()
         .filter_map(|(id, _)| client.state_db.get(id).ok())
         .collect::<Vec<_>>();
     Ok(states)
@@ -191,7 +192,7 @@ pub fn synchronize(client: &Client, state: &State) -> Result<(), Error> {
 
     // Grab the entries for the new state
     let mut all_kernels = vec![];
-    all_states.insert(0, state.clone());
+    all_states.push(state.clone());
     for state in all_states.iter() {
         let layouts = layouts_for_state(client, state)?;
         let local_kernels = kernel_files_from_state(&layouts, &kernel_pattern);
@@ -200,10 +201,11 @@ pub fn synchronize(client: &Client, state: &State) -> Result<(), Error> {
     }
 
     // pipe all of our entries into blsforme
-    let mut entries = all_kernels
+    let entries = all_kernels
         .iter()
         .flat_map(|&(ref kernels, state_id)| {
             let rootref = &root;
+            let configref = &config;
             kernels.iter().filter_map(move |k| {
                 let sysroot = if state.id == state_id {
                     rootref.clone()
@@ -216,11 +218,8 @@ pub fn synchronize(client: &Client, state: &State) -> Result<(), Error> {
                 }
 
                 let local_schema = os_schema_for_root(&sysroot).ok();
-                let entry = Entry::new(k)
-                    .with_cmdline(CmdlineEntry {
-                        name: "---fstx---".to_owned(),
-                        snippet: format!("moss.fstx={state_id}"),
-                    })
+                let entry = Entry::new(configref, k)
+                    .with_cmdline(format!("moss.fstx={state_id}"))
                     .with_state_id(i32::from(state_id))
                     .with_sysroot(sysroot);
 
@@ -232,12 +231,6 @@ pub fn synchronize(client: &Client, state: &State) -> Result<(), Error> {
         })
         .collect::<Vec<_>>();
 
-    for entry in entries.iter_mut() {
-        if let Err(e) = entry.load_cmdline_snippets(&config) {
-            log::warn!("Failed to load cmdline snippets: {e}");
-        }
-    }
-
     // no usable entries, lets get out of here.
     if entries.is_empty() {
         return Ok(());
@@ -245,7 +238,7 @@ pub fn synchronize(client: &Client, state: &State) -> Result<(), Error> {
 
     // If we can't get a manager, find, but don't bomb. Its probably a topology failure.
     let manager = match blsforme::Manager::new(&config) {
-        Ok(m) => m.with_entries(entries.into_iter()).with_bootloader_assets(booty_bits),
+        Ok(m) => m.with_entries(entries).with_bootloader_assets(booty_bits),
         Err(_) => return Ok(()),
     };
 
@@ -294,7 +287,7 @@ pub fn print_status(installation: &Installation) -> Result<(), Error> {
         }
     }
 
-    println!("Global cmdline : {:?}", manager.cmdline());
+    println!("Global cmdline : {:?}", manager.global_cmdline());
 
     Ok(())
 }


### PR DESCRIPTION
Updates blsforme to include new fixes / features merged from this stack: https://github.com/aerynOS/blsforme/pull/68

We now pass entries in state ascending order to ensure that the underlying blsforme logic which retains asset conflicts adds / links the appropriate `.{id}` suffix for conflicting assets in ascending order along w/ the states -> entries passed in. 