### PR TITLE
moss: Use moss assets dir for blit strategy identification

### DIFF
--- a/moss/src/fstree/native.rs
+++ b/moss/src/fstree/native.rs
@@ -82,7 +82,8 @@ fn identify_blit_strategy(installation: &Installation, blit_target: &Path) -> Bl
         return strategy;
     }
 
-    let from = installation.cache_path(".link-test");
+    // Link from & to same places that we will link during blit
+    let from = installation.assets_path("v2/.link-test");
     let to = blit_target.join(".link-test");
 
     let identify = || -> io::Result<_> {


### PR DESCRIPTION
We have a regression in blit strategy caused by the new identification method when moss is invoked with `moss --cache` and the specified cache dir is located on a separate filesystem, it then falls back to copy.

Using cache dir as the _source_ of the identification check function is incorrect. It needs to use the same assets path that we link CAS files from so that it identifies the appropriate blit strategy.

We figured this out because our ISO generation process uses `moss --cache` on one FS and `-D` on `/tmp` which caused `copy` to get used and balloon that root.