### PR TITLE
moss: Don't nuke blit_target, only nuke usr/

### DIFF
--- a/moss/src/client/verify.rs
+++ b/moss/src/client/verify.rs
@@ -23,6 +23,7 @@ use crate::{
     package, runtime, signal, state,
 };
 
+#[allow(clippy::branches_sharing_code)]
 pub fn verify(client: &Client, yes: bool, verbose: bool) -> Result<(), client::Error> {
     println!("Verifying assets");
 
@@ -328,6 +329,9 @@ pub fn verify(client: &Client, yes: bool, verbose: bool) -> Result<(), client::E
                 }
             })?;
             client.archive_state(state.id)?;
+            // Cleanup staging dir used as ephemeral blit target now that we've
+            // archived out of it
+            fs::remove_dir_all(client.installation.staging_dir())?;
         }
 
         println!(" {} state #{}", "»".green(), state.id);

--- a/moss/src/fstree/native.rs
+++ b/moss/src/fstree/native.rs
@@ -181,9 +181,13 @@ pub fn blit_root(installation: &Installation, tree: &vfs::Tree<PendingFile>, bli
 
     let is_user_root = Uid::effective().is_root();
 
-    // Recreate dir
-    let _ = fs::remove_dir_all(blit_target);
-    mkdir(blit_target, Mode::from_bits_truncate(0o755))?;
+    // Ensure dir exists
+    if !blit_target.exists() {
+        mkdir(blit_target, Mode::from_bits_truncate(0o755))?;
+    }
+    // Ensure usr/ it removed since we will now be
+    // blitting it out
+    let _ = fs::remove_dir_all(blit_target.join("usr"));
 
     // Ensure umask is cleared so we get exact modes
     let old_umask = umask(Mode::empty());


### PR DESCRIPTION
This doesn't matter when blitting to `staging` when moss is creating stateful fstrees that need to be activated. It impacts use of `moss it --to` when blitting to a detached root.

This allows `moss it --to` to update the detached root usr/ & run system triggers on that detached root without nuking all other persistent data on that detached root, such as if that root is used via some container.

CC: @lumi-me-not 