### PR TITLE
moss: Handle unsupported repo versions

### DIFF
--- a/moss/src/repository/format/root_index.rs
+++ b/moss/src/repository/format/root_index.rs
@@ -28,6 +28,22 @@ impl RootIndex {
         self.get_history(ident).map(|meta| (ident, meta))
     }
 
+    /// Returns the defined `upgrade_via` history for the specified
+    /// [`Format`] if it exists, otherwise returns the latest history
+    /// version for this format.
+    pub fn upgrade_via_or_latest_history<'a>(&'a self, format: &Format) -> Option<(&'a Identifier, &'a HistoryMeta)> {
+        let upgrade_via = match format {
+            Format::V0 => self.formats.v0.upgrade_via.as_ref(),
+            Format::Legacy | Format::Unsupported(_) => None,
+        }
+        .and_then(|ident| self.resolve_version_to_history(ident));
+
+        upgrade_via.or_else(|| {
+            // History is sorted in DESC order where most recent will be listed first.
+            self.history.iter().find(|(_, meta)| meta.format == *format)
+        })
+    }
+
     fn get_history(&self, version: &Identifier) -> Option<&HistoryMeta> {
         self.history.get(version)
     }

--- a/moss/src/repository/mod.rs
+++ b/moss/src/repository/mod.rs
@@ -10,6 +10,7 @@ use derive_more::{AsRef, Debug, Display, From, Into};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::io;
+use tracing::warn;
 use url::Url;
 
 use config::Config;
@@ -282,22 +283,42 @@ impl RootIndexSource {
             .ok_or_else(|| ResolveHistoryIndexUriError::MissingRootIndexVersion(self.version.clone()))?;
 
         if matches!(history_meta.format, Format::Unsupported(_)) {
-            let upgrade_via_index_uri = root_index
-                .formats
-                .v0
-                .upgrade_via
-                .as_ref()
-                .map(|version| {
-                    root_index
-                        .resolve_version_to_history(version)
-                        .ok_or_else(|| ResolveHistoryIndexUriError::MissingRootIndexVersion(version.clone()))
-                })
-                .transpose()?
-                .map(|(ident, _)| self.history_index_uri(ident));
+            // TODO: We eventually want to trigger a self-upgrade flow once the targeted version
+            // moves into a newer unsupported format. For now, we simply saturate at the "upgrade_via"
+            // or latest version of the latest supported format by this moss, which should always
+            // include a moss that understands the next format.
+            //
+            // This allows the user to still sync & have a newer moss that they can sync w/ again
+            // onto the new format that their targeted version lands on.
+            //
+            // A future self-upgrade flow can be more intelligent in that it:
+            //
+            // - Only updates moss from the "upgrade_via" history
+            // - Reinvokes the newer moss to initiate the original sync
+            //
+            // This would allow moss to both self upgrade as many times as needed and then initiate
+            // the final on the actual format the targeted version exists, without the user having
+            // to run sync manually multiple times.
+            if let Some((ident, _)) = root_index.upgrade_via_or_latest_history(&Format::LATEST) {
+                warn!(
+                    root_index = %root_index_uri,
+                    requested_version = %self.version,
+                    requested_format = %history_meta.format,
+                    supported_version = %format::ScopedIdentifier::History(ident.clone()),
+                    supported_format = %Format::LATEST,
+                    "Requested repo index version is on a newer unsupported format, using latest supported version instead"
+                );
+                return Ok(ResolvedHistoryIndexUri::Supported(self.history_index_uri(ident)));
+            }
 
+            // TODO: This is the trigger for the self-upgrade path. For now, it is
+            // effectively "disabled" due to the previous expression.
+            //
+            // Once this links to a proper `self-upgrade` flow, we can remove the above
+            // expression and let this flow again.
             return Ok(ResolvedHistoryIndexUri::Unsupported {
                 root_index_uri,
-                upgrade_via_index_uri,
+                upgrade_via_index_uri: None,
                 version: self.version.clone(),
                 format: history_meta.format.clone(),
             });


### PR DESCRIPTION
Unsupported repo versions were currently stubbed to a branch which intends to hook into a future `self-upgrade` flow that isn't defined yet. This means that all moss clients from v0 inception through now, if faced with a future format bump, will panic instead of seamlessly upgrading.

In-lieu of finising that self-upgrade flow, we can instead ensure moss instead sync's to the latest supported format version. This would allow moss to still sync to a version which includes the newer format moss, which would allow the user to sync again until they finally land on the appropriate version.

The only downside with this approach is it requires the user invokes `moss sync` as many times as needed until no more updates are available. But they at least have a path to do so.

The `self-upgrade` flow intends to automate this so moss will automatically re-invoke the newer moss until it lands on the desired version. That is a larger change and still pending development.